### PR TITLE
Update README for adding skills to SkillHandler'

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Create a class named `SKILL_IDInfo` (e.g. `WeatherInfo`) overriding `SkillInfo`:
 	4. At the end add `.output
 4. _\[Optional\]_ If your skill wants to present some preferences to the user, it has to do so by overriding `getPreferenceFragment()` (return `null` otherwise). Create a subclass of `SKILL_IDInfo` named `Preferences` extending `PreferenceFragmentCompat` (Android requires you not to use anonymous classes) and override the `onCreatePreferences()` as you would do normally. `getPreferenceFragment()` should then `return new Preferences()`. Make sure the `hasPreferences` parameter you use in the constructor (see [5.1](https://github.com/Stypox/dicio-android#5-skill-info)) reflects whether there are preferences or not. 
 
+#### 6. **List skill for SkillHandler**
+Under `org.dicio.dicio_android.Skills.SkillHandler`, update the `SKILL_INFO_LIST` by adding `add(new SKILL_IDInfo())`; this will make your skill visible to Dicio.   
+
 #### **Notes**
 - `skillContext` is provided in many places and can be used to **access resources and services**, similarly to Andorid's `context`.
 - If your input recognizer, processor or output generator use some resources that need to be cleaned up in order **not to create memory leaks**, make sure to override the `cleanup()` method.


### PR DESCRIPTION
This PR updates dicio's README with additional instructions for users attempting to add new skills. Specifically, the updated README now includes the final step that includes updating the SkillHandler to make this skill visible for use at runtime. This PR addresses the (perhaps non-specific) issue referred to in #89. The sufficiency of this documentation update for adding skills was confirmed by successfully compiling dicio-assistant with a new skill (shortly forthcoming) against OpenJDK 14 using the default Gradle 7.4 toolchain as specified in commit 32aeadd, and running on Android 12. 