### PR TITLE
Fix crash when downloading Vosk model on old APIs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,11 +6,20 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <!-- required by the download manager for APIs < Q -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+
+    <!-- the open skill needs to query all apps -->
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
-        tools:ignore="QueryAllPackagesPermission" /> <!-- the open skill needs to query all apps -->
-    <uses-permission android:name="android.permission.READ_CONTACTS" /> <!-- the telephone skill needs to query all contacts -->
-    <uses-permission android:name="android.permission.CALL_PHONE" /> <!-- the telephone skill needs to call contacts -->
+        tools:ignore="QueryAllPackagesPermission" />
+
+    <!-- the telephone skill needs to query contacts and call them -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.CALL_PHONE" />
 
     <application
         android:name=".App"


### PR DESCRIPTION
This PR requests external storage permission on Android < Q, as it is [required](https://developer.android.com/reference/android/app/DownloadManager.Request#setDestinationUri(android.net.Uri)) by the `DownloadManager` class.

Fixes #103

Testing APK: [app-debug.zip](https://github.com/Stypox/dicio-android/files/10218414/app-debug.zip)