### PR TITLE
Added prompt message + preference for Auto-finish

### DIFF
--- a/app/src/main/java/org/dicio/dicio_android/input/stt_service/SttServiceActivity.java
+++ b/app/src/main/java/org/dicio/dicio_android/input/stt_service/SttServiceActivity.java
@@ -1,8 +1,5 @@
 package org.dicio.dicio_android.input.stt_service;
 
-import static android.speech.RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT;
-import static android.speech.RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT_BUNDLE;
-
 import android.app.PendingIntent;
 import android.app.SearchManager;
 import android.content.Context;
@@ -12,9 +9,6 @@ import android.speech.RecognizerIntent;
 import android.util.Log;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
-
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatDialog;
 
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 
@@ -32,6 +26,12 @@ import org.dicio.dicio_android.util.ThemeUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatDialog;
+
+import static android.speech.RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT;
+import static android.speech.RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT_BUNDLE;
 
 public class SttServiceActivity extends BaseActivity {
     private static final String TAG = SttServiceActivity.class.getSimpleName();
@@ -69,6 +69,9 @@ public class SttServiceActivity extends BaseActivity {
                         R.style.LightAppTheme, R.style.DarkAppTheme));
         final LayoutInflater layoutInflater = LayoutInflater.from(wrappedContext);
         binding = DialogSttServiceBinding.inflate(layoutInflater);
+        final String prompt = speechExtras.getString(
+                RecognizerIntent.EXTRA_PROMPT, getString(R.string.stt_say_something));
+        binding.userInput.setHint(prompt);
 
         dialog = new BottomSheetDialog(wrappedContext);
         dialog.setCancelable(true);
@@ -104,7 +107,9 @@ public class SttServiceActivity extends BaseActivity {
         speechInputDevice.setInputDeviceListener(new InputDevice.InputDeviceListener() {
             @Override
             public void onTryingToGetInput() {
-                binding.userInput.setHint(R.string.stt_say_something);
+                final String prompt = speechExtras.getString(
+                        RecognizerIntent.EXTRA_PROMPT, getString(R.string.stt_say_something));
+                binding.userInput.setHint(prompt);
                 binding.userInput.setEnabled(false);
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,9 @@
     <string name="pref_search_engine_duckduckgo" translatable="false">DuckDuckGo</string>
     <string name="pref_weather_default_city">Default city</string>
     <string name="pref_weather_default_city_using_ip_info">Set the city to use for weather when you do not explicitly say one. The current behaviour is to get the location from IP info.</string>
+    <string name="pref_stt_auto_finish_title">Speech-to-Text Service</string>
+    <string name="pref_stt_auto_finish_summary_on">Automatically send speech result to requesting app when listening finished</string>
+    <string name="pref_stt_auto_finish_summary_off">Wait for manual confirmation before sending speech result to requesting app</string>
     <string name="eval_missing_permissions">The skill \"%1$s\" needs these permissions to work: %2$s</string>
     <string name="eval_fatal_error">Could not evaluate your request</string>
     <string name="eval_network_error">Network error</string>

--- a/app/src/main/res/values/strings_keys.xml
+++ b/app/src/main/res/values/strings_keys.xml
@@ -23,4 +23,6 @@
     <string name="pref_val_search_engine_duckduckgo" translatable="false">duckduckgo</string>
 
     <string name="pref_key_weather_default_city" translatable="false">weather_default_city</string>
+
+    <string name="pref_key_stt_auto_finish" translatable="false">stt_auto_finish</string>
 </resources>

--- a/app/src/main/res/xml/pref_io.xml
+++ b/app/src/main/res/xml/pref_io.xml
@@ -27,4 +27,13 @@
         android:key="@string/pref_key_speech_output_method"
         android:summary="@string/pref_speech_output_method_summary"
         android:title="@string/pref_speech_output_method" />
+
+    <SwitchPreference
+        android:defaultValue="true"
+        android:key="@string/pref_key_stt_auto_finish"
+        android:title="@string/pref_stt_auto_finish_title"
+        android:summaryOn="@string/pref_stt_auto_finish_summary_on"
+        android:summaryOff="@string/pref_stt_auto_finish_summary_off"
+        android:icon="?attr/iconRecordVoiceOver"
+        />
 </PreferenceScreen>


### PR DESCRIPTION
- prompt message shows up as hint (if none is provided, default is still "Say something...")
- Auto finish preference setting added: Reason: Vosk is good, but at least in German it is not perfect. Therefore it is easier (and faster: avoid waiting for loading vosk model again) if user gets the possibility to confirm or speak anew before reporting the result back to requesting app.
- added the TODO from #100 for optional (and seldom used, if ever) extras like EXTRA_BIASING_STRINGS, EXTRA_LANGUAGE for future reference and remind, which extras may be helpful for vosk recognition to improve the results