### PR TITLE
Fixed AGP version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.Stypox:dicio-sentences-compiler:ae228425c4071448ec09c6026b5b3a80e5744818'
     }


### PR DESCRIPTION
Fixed issue -
The project uses an incompatible version (AGP 8.1.1) of the Android Gradle plugin. The latest supported version is AGP 8.0.2