### PR TITLE
Add RecognitionService, so Dicio appears under Voice Input

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,15 +22,6 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 
-    <queries>
-        <!-- To access Speech recognizer via system interface on Android 11+
-        https://developer.android.com/reference/android/speech/SpeechRecognizer#createSpeechRecognizer(android.content.Context,%20android.content.ComponentName) -->
-        <intent>
-            <action
-                android:name="android.speech.RecognitionService" />
-        </intent>
-    </queries>
-
     <!-- allowBackup=false because of a critical nasty bug: https://medium.com/p/924c91bafcac -->
     <application
         android:name=".App"
@@ -88,12 +79,13 @@
 
         <service
             android:name=".io.input.stt_service.SttService"
-            android:enabled="true"
-            android:exported="true"
-            android:description="@string/pref_input_method_vosk"
-            android:icon="@mipmap/ic_launcher"
+            android:description="@string/stt_service_label"
             android:directBootAware="true"
-            android:foregroundServiceType="microphone">
+            android:exported="true"
+            android:foregroundServiceType="microphone"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/stt_service_label"
+            android:permission="android.permission.RECORD_AUDIO">
             <intent-filter>
                 <action android:name="android.speech.RecognitionService"/>
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,15 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 
+    <queries>
+        <!-- To access Speech recognizer via system interface on Android 11+
+        https://developer.android.com/reference/android/speech/SpeechRecognizer#createSpeechRecognizer(android.content.Context,%20android.content.ComponentName) -->
+        <intent>
+            <action
+                android:name="android.speech.RecognitionService" />
+        </intent>
+    </queries>
+
     <!-- allowBackup=false because of a critical nasty bug: https://medium.com/p/924c91bafcac -->
     <application
         android:name=".App"
@@ -76,5 +85,22 @@
                 <action android:name="android.speech.action.RECOGNIZE_SPEECH" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".io.input.stt_service.SttService"
+            android:enabled="true"
+            android:exported="true"
+            android:description="@string/pref_input_method_vosk"
+            android:icon="@mipmap/ic_launcher"
+            android:directBootAware="true"
+            android:foregroundServiceType="microphone">
+            <intent-filter>
+                <action android:name="android.speech.RecognitionService"/>
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data
+                android:name="android.speech"
+                android:resource="@xml/stt_service_metadata" />
+        </service>
     </application>
 </manifest>

--- a/app/src/main/kotlin/org/stypox/dicio/di/SttInputDeviceWrapper.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/SttInputDeviceWrapper.kt
@@ -31,7 +31,9 @@ import javax.inject.Singleton
 interface SttInputDeviceWrapper {
     val uiState: StateFlow<SttState?>
 
-    fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?)
+    fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?): Boolean
+
+    fun stopListening()
 
     fun onClick(eventListener: (InputEvent) -> Unit)
 }
@@ -98,8 +100,12 @@ class SttInputDeviceWrapperImpl(
     }
 
 
-    override fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?) {
-        sttInputDevice?.tryLoad(thenStartListeningEventListener)
+    override fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?): Boolean {
+        return sttInputDevice?.tryLoad(thenStartListeningEventListener) ?: false
+    }
+
+    override fun stopListening() {
+        sttInputDevice?.stopListening()
     }
 
     override fun onClick(eventListener: (InputEvent) -> Unit) {

--- a/app/src/main/kotlin/org/stypox/dicio/io/input/SttInputDevice.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/input/SttInputDevice.kt
@@ -6,7 +6,9 @@ import org.stypox.dicio.ui.home.SttState
 interface SttInputDevice {
     val uiState: StateFlow<SttState>
 
-    fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?)
+    fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?): Boolean
+
+    fun stopListening()
 
     fun onClick(eventListener: (InputEvent) -> Unit)
 

--- a/app/src/main/kotlin/org/stypox/dicio/io/input/stt_service/SttService.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/input/stt_service/SttService.kt
@@ -90,6 +90,7 @@ class SttService : RecognitionService() {
         }
 
         if (!willStartListening) {
+            Log.w(TAG, "Could not start STT recognizer")
             logRemoteExceptions { listener.error(ERROR_LANGUAGE_UNAVAILABLE) }
         }
     }

--- a/app/src/main/kotlin/org/stypox/dicio/io/input/stt_service/SttService.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/input/stt_service/SttService.kt
@@ -1,0 +1,72 @@
+package org.stypox.dicio.io.input.stt_service
+
+import android.content.Intent
+import android.os.Bundle
+import android.speech.RecognitionService
+import android.speech.SpeechRecognizer
+import dagger.hilt.android.AndroidEntryPoint
+import org.stypox.dicio.di.SttInputDeviceWrapper
+import org.stypox.dicio.io.input.InputEvent
+import javax.inject.Inject
+
+
+@AndroidEntryPoint
+class SttService : RecognitionService() {
+
+    @Inject
+    lateinit var sttInputDevice: SttInputDeviceWrapper
+
+    override fun onStartListening(recognizerIntent: Intent, listener: Callback) {
+        var beginningOfSpeech = true
+        val willStartListening = sttInputDevice.tryLoad { inputEvent ->
+            when (inputEvent) {
+                is InputEvent.Error -> {
+                    listener.error(SpeechRecognizer.ERROR_SERVER)
+                }
+                is InputEvent.Final -> {
+                    val results = Bundle()
+                    results.putStringArrayList(
+                        SpeechRecognizer.RESULTS_RECOGNITION,
+                        ArrayList(inputEvent.utterances.map { it.first })
+                    )
+                    results.putFloatArray(
+                        SpeechRecognizer.CONFIDENCE_SCORES,
+                        inputEvent.utterances.map { it.second }.toFloatArray()
+                    )
+                    listener.results(results)
+                    listener.endOfSpeech()
+                }
+                InputEvent.None -> {
+                    listener.error(SpeechRecognizer.ERROR_NO_MATCH)
+                    listener.endOfSpeech()
+                }
+                is InputEvent.Partial -> {
+                    if (beginningOfSpeech) {
+                        listener.beginningOfSpeech()
+                        beginningOfSpeech = false
+                    }
+                    val partResult = Bundle()
+                    partResult.putStringArrayList(
+                        SpeechRecognizer.RESULTS_RECOGNITION,
+                        arrayListOf(inputEvent.utterance)
+                    )
+                    listener.partialResults(partResult)
+                }
+            }
+        }
+
+        if (!willStartListening) {
+            // TODO choose better error to indicate that manual intervention is required to
+            //  download the Vosk model
+            listener.error(SpeechRecognizer.ERROR_NETWORK)
+        }
+    }
+
+    override fun onCancel(listener: Callback) {
+        sttInputDevice.stopListening()
+    }
+
+    override fun onStopListening(listener: Callback) {
+        sttInputDevice.stopListening()
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/io/input/stt_service/SttService.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/input/stt_service/SttService.kt
@@ -16,6 +16,18 @@ import java.util.Locale
 import javax.inject.Inject
 
 
+// TODO this class is really simple at the moment, but many more things could be implemented, e.g.:
+//  - allowing an SttInputDevice to download/support multiple languages
+//  - handling more EXTRAs, e.g. EXTRA_LANGUAGE, EXTRA_LANGUAGE_PREFERENCE,
+//  EXTRA_ONLY_RETURN_LANGUAGE_PREFERENCE, EXTRA_LANGUAGE_MODEL, LANGUAGE_MODEL_FREE_FORM,
+//  LANGUAGE_MODEL_WEB_SEARCH, EXTRA_SEGMENTED_SESSION,
+//  EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS,
+//  EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS,
+//  EXTRA_SPEECH_INPUT_MINIMUM_LENGTH_MILLIS, EXTRA_AUDIO_SOURCE, EXTRA_AUDIO_SOURCE_CHANNEL_COUNT,
+//  EXTRA_AUDIO_SOURCE_ENCODING, EXTRA_AUDIO_SOURCE_SAMPLING_RATE, EXTRA_BIASING_STRINGS,
+//  EXTRA_ENABLE_BIASING_DEVICE_CONTEXT
+//  - if the SttInputDevice is already busy (e.g. another service is using it, or another part of
+//  Dicio is using it), that needs to be reported with ERROR_BUSY
 @AndroidEntryPoint
 class SttService : RecognitionService() {
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,4 +162,5 @@
     <string name="skill_timer_query_name">Timer %1$s expires in %2$s</string>
     <string name="skill_timer_query_last">The last timer expires in %1$s</string>
     <string name="skill_timer_none_canceled">OK, no timer was canceled</string>
+    <string name="stt_service_label">Dicio offline speech recognition</string>
 </resources>

--- a/app/src/main/res/xml/stt_service_metadata.xml
+++ b/app/src/main/res/xml/stt_service_metadata.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- TODO actually set a proper settingsActivity -->
 <recognition-service
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:settingsActivity="org.stypox.dicio.MainActivity" />

--- a/app/src/main/res/xml/stt_service_metadata.xml
+++ b/app/src/main/res/xml/stt_service_metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<recognition-service
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:settingsActivity="org.stypox.dicio.MainActivity" />


### PR DESCRIPTION
This PR implements a RecognitionService, which provides support to other applications to recognize audio in the background. This is done by adding `<meta-data name="android.speech"/>` and `<intent-filter><action name="RecognitionService"/>` under the service definition in the manifest. The service implementation is pretty straightforward and simply uses the currently configured STT input device (only Vosk is available at the moment) to recognize speech.

The work in this PR was heavily inspired by #161, but this PR only provides a really barebone implementation, which will need to be improved in the future (see the TODOs at the top of `SttService`). Thank you @nebkrid!

I tested with Koñele and the service works.

Closes #126.

Testing APK: https://github.com/Stypox/testing-apks/releases/download/4/app-debug.apk