### PR TITLE
In Android Studio, Build; Make Project failed with an error

### DIFF
--- a/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSttInputDeviceWrapper.kt
+++ b/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSttInputDeviceWrapper.kt
@@ -8,7 +8,11 @@ import org.stypox.dicio.ui.home.SttState
 class FakeSttInputDeviceWrapper : SttInputDeviceWrapper {
     override val uiState: MutableStateFlow<SttState> = MutableStateFlow(SttState.NotInitialized)
 
-    override fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?) {
+    override fun tryLoad(thenStartListeningEventListener: ((InputEvent) -> Unit)?): Boolean {
+        return TODO("Provide the return value")
+    }
+
+    override fun stopListening() {
     }
 
     override fun onClick(eventListener: (InputEvent) -> Unit) {


### PR DESCRIPTION
In Android Studio, Build; Make Project failed with an error due to lacking implementation of inherited methods in non-virtual child class. This commit fixed that by providing the empty implementation, and a fix of a return value.