### PR TITLE
Update calculator_operators.yml

### DIFF
--- a/app/src/main/sentences/en/calculator_operators.yml
+++ b/app/src/main/sentences/en/calculator_operators.yml
@@ -5,7 +5,7 @@ subtraction:
   - minus|(subtract|subtracting|subtraction from?)
 
 multiplication:
-  - times|(multiply|multiplying|multiplied|multiplication by?)
+  - times|of|(multiply|multiplying|multiplied|multiplication by?)
 
 division:
   - (divide|division|dividing|divided by?)|over


### PR DESCRIPTION
Added "of" to the list of calculator operators for multiplication. I built the app, and it works as expected. "Half of", "Quarter of" and such all work. 

Fixes #107