### PR TITLE
Allow users to import a custom wake word model

### DIFF
--- a/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSttInputDeviceWrapper.kt
+++ b/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSttInputDeviceWrapper.kt
@@ -18,6 +18,6 @@ class FakeSttInputDeviceWrapper : SttInputDeviceWrapper {
     override fun onClick(eventListener: (InputEvent) -> Unit) {
     }
 
-    override fun releaseResources() {
+    override fun reinitializeToReleaseResources() {
     }
 }

--- a/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeWakeDeviceWrapper.kt
+++ b/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeWakeDeviceWrapper.kt
@@ -14,5 +14,5 @@ class FakeWakeDeviceWrapper : WakeDeviceWrapper {
 
     override fun frameSize(): Int = 1312
 
-    override fun releaseResources() {}
+    override fun reinitializeToReleaseResources() {}
 }

--- a/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeWakeDeviceWrapper.kt
+++ b/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeWakeDeviceWrapper.kt
@@ -7,12 +7,10 @@ import org.stypox.dicio.io.wake.WakeState
 
 class FakeWakeDeviceWrapper : WakeDeviceWrapper {
     override val state: StateFlow<WakeState?> = MutableStateFlow(null)
+    override val isHeyDicio: StateFlow<Boolean> = MutableStateFlow(true)
 
     override fun download() {}
-
     override fun processFrame(audio16bitPcm: ShortArray): Boolean = false
-
     override fun frameSize(): Int = 1312
-
     override fun reinitializeToReleaseResources() {}
 }

--- a/app/src/main/kotlin/org/stypox/dicio/MainActivity.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/MainActivity.kt
@@ -27,7 +27,6 @@ import org.stypox.dicio.di.SttInputDeviceWrapper
 import org.stypox.dicio.di.WakeDeviceWrapper
 import org.stypox.dicio.eval.SkillEvaluator
 import org.stypox.dicio.io.wake.WakeService
-import org.stypox.dicio.io.wake.WakeState
 import org.stypox.dicio.io.wake.WakeState.Loaded
 import org.stypox.dicio.io.wake.WakeState.Loading
 import org.stypox.dicio.io.wake.WakeState.NotLoaded
@@ -165,7 +164,7 @@ class MainActivity : BaseActivity() {
     override fun onDestroy() {
         // the wake word service remains active in the background,
         // so we need to release resources that it does not need manually
-        sttInputDevice.releaseResources()
+        sttInputDevice.reinitializeToReleaseResources()
         isCreated -= 1
         super.onDestroy()
     }

--- a/app/src/main/kotlin/org/stypox/dicio/di/SttInputDeviceWrapper.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/SttInputDeviceWrapper.kt
@@ -42,7 +42,7 @@ interface SttInputDeviceWrapper {
 
     fun onClick(eventListener: (InputEvent) -> Unit)
 
-    fun releaseResources()
+    fun reinitializeToReleaseResources()
 }
 
 class SttInputDeviceWrapperImpl(
@@ -154,7 +154,7 @@ class SttInputDeviceWrapperImpl(
         sttInputDevice?.onClick(eventListener)
     }
 
-    override fun releaseResources() {
+    override fun reinitializeToReleaseResources() {
         scope.launch { changeInputDeviceTo(inputDeviceSetting) }
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/di/WakeDeviceWrapper.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/WakeDeviceWrapper.kt
@@ -26,6 +26,8 @@ import javax.inject.Singleton
 interface WakeDeviceWrapper {
     val state: StateFlow<WakeState?>
 
+    val openWakeWordDevice: OpenWakeWordDevice?
+
     fun download()
 
     fun processFrame(audio16bitPcm: ShortArray): Boolean
@@ -90,6 +92,9 @@ class WakeDeviceWrapperImpl(
             WAKE_DEVICE_NOTHING -> null
         }
     }
+
+    override val openWakeWordDevice: OpenWakeWordDevice?
+        get() = wakeDevice as? OpenWakeWordDevice
 
     private suspend fun restartUiStateJob() {
         stateJob?.cancel()

--- a/app/src/main/kotlin/org/stypox/dicio/di/WakeDeviceWrapper.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/WakeDeviceWrapper.kt
@@ -39,6 +39,8 @@ interface WakeDeviceWrapper {
     fun frameSize(): Int
 
     fun releaseResources()
+
+    fun isHeyDicio(): Boolean
 }
 
 typealias DataStoreWakeDevice = org.stypox.dicio.settings.datastore.WakeDevice
@@ -137,6 +139,10 @@ class WakeDeviceWrapperImpl(
     override fun releaseResources() {
         changeWakeDeviceTo(currentSetting)
     }
+
+    override fun isHeyDicio(): Boolean =
+        // true by default
+        _currentDevice.value?.isHeyDicio() ?: true
 }
 
 @Module

--- a/app/src/main/kotlin/org/stypox/dicio/di/WakeDeviceWrapper.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/WakeDeviceWrapper.kt
@@ -9,24 +9,28 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import org.stypox.dicio.io.wake.WakeDevice
 import org.stypox.dicio.io.wake.WakeState
 import org.stypox.dicio.io.wake.oww.OpenWakeWordDevice
 import org.stypox.dicio.settings.datastore.UserSettings
-import org.stypox.dicio.settings.datastore.WakeDevice.*
+import org.stypox.dicio.settings.datastore.WakeDevice.UNRECOGNIZED
+import org.stypox.dicio.settings.datastore.WakeDevice.WAKE_DEVICE_NOTHING
+import org.stypox.dicio.settings.datastore.WakeDevice.WAKE_DEVICE_OWW
+import org.stypox.dicio.settings.datastore.WakeDevice.WAKE_DEVICE_UNSET
 import org.stypox.dicio.util.distinctUntilChangedBlockingFirst
 import javax.inject.Singleton
 
 interface WakeDeviceWrapper {
     val state: StateFlow<WakeState?>
 
-    val openWakeWordDevice: OpenWakeWordDevice?
+    val currentDevice: StateFlow<WakeDevice?>
 
     fun download()
 
@@ -45,17 +49,16 @@ class WakeDeviceWrapperImpl(
     private val okHttpClient: OkHttpClient,
 ) : WakeDeviceWrapper {
     private val scope = CoroutineScope(Dispatchers.Default)
-    private var stateJob: Job? = null
 
     private var currentSetting: DataStoreWakeDevice
-    private var wakeDevice: WakeDevice?
     private var lastFrameHadWrongSize = false
 
     // null means that the user has not enabled any STT input device
     private val _state: MutableStateFlow<WakeState?> = MutableStateFlow(null)
     override val state: StateFlow<WakeState?> = _state
 
-
+    private val _currentDevice: MutableStateFlow<WakeDevice?>
+    override val currentDevice: StateFlow<WakeDevice?>
 
     init {
         // Run blocking, because the data store is always available right away since LocaleManager
@@ -65,9 +68,17 @@ class WakeDeviceWrapperImpl(
             .distinctUntilChangedBlockingFirst()
 
         currentSetting = firstWakeDevice
-        wakeDevice = buildInputDevice(firstWakeDevice)
+        _currentDevice = MutableStateFlow(buildInputDevice(firstWakeDevice))
+        currentDevice = _currentDevice
+
         scope.launch {
-            restartUiStateJob()
+            _currentDevice.collectLatest { newWakeDevice ->
+                if (newWakeDevice == null) {
+                    _state.emit(null)
+                } else {
+                    newWakeDevice.state.collect { _state.emit(it) }
+                }
+            }
         }
 
         scope.launch {
@@ -75,13 +86,14 @@ class WakeDeviceWrapperImpl(
         }
     }
 
-    private suspend fun changeWakeDeviceTo(setting: DataStoreWakeDevice) {
-        val prevWakeDevice = wakeDevice
+    private fun changeWakeDeviceTo(setting: DataStoreWakeDevice) {
         currentSetting = setting
-        wakeDevice = buildInputDevice(setting)
+        val newWakeDevice = buildInputDevice(setting)
         lastFrameHadWrongSize = false
-        prevWakeDevice?.destroy()
-        restartUiStateJob()
+        _currentDevice.update { prevWakeDevice ->
+            prevWakeDevice?.destroy()
+            newWakeDevice
+        }
     }
 
     private fun buildInputDevice(setting: DataStoreWakeDevice): WakeDevice? {
@@ -93,28 +105,13 @@ class WakeDeviceWrapperImpl(
         }
     }
 
-    override val openWakeWordDevice: OpenWakeWordDevice?
-        get() = wakeDevice as? OpenWakeWordDevice
-
-    private suspend fun restartUiStateJob() {
-        stateJob?.cancel()
-        val newWakeDevice = wakeDevice
-        if (newWakeDevice == null) {
-            stateJob = null
-            _state.emit(null)
-        } else {
-            stateJob = scope.launch {
-                newWakeDevice.state.collect { _state.emit(it) }
-            }
-        }
-    }
-
     override fun download() {
-        wakeDevice?.download()
+        _currentDevice.value?.download()
     }
 
     override fun processFrame(audio16bitPcm: ShortArray): Boolean {
-        val device = wakeDevice ?: throw IllegalArgumentException("No wake word device is enabled")
+        val device = _currentDevice.value
+            ?: throw IllegalArgumentException("No wake word device is enabled")
 
         if (audio16bitPcm.size != device.frameSize()) {
             if (lastFrameHadWrongSize) {
@@ -134,13 +131,11 @@ class WakeDeviceWrapperImpl(
     }
 
     override fun frameSize(): Int {
-        return wakeDevice?.frameSize() ?: 0
+        return _currentDevice.value?.frameSize() ?: 0
     }
 
     override fun releaseResources() {
-        scope.launch {
-            changeWakeDeviceTo(currentSetting)
-        }
+        changeWakeDeviceTo(currentSetting)
     }
 }
 

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeDevice.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeDevice.kt
@@ -19,4 +19,9 @@ interface WakeDevice {
     fun frameSize(): Int
 
     fun destroy()
+
+    /**
+     * Returns `true` if the wake word is "Hey Dicio", `false` if a custom model is being used
+     */
+    fun isHeyDicio(): Boolean
 }

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
@@ -148,7 +148,12 @@ class WakeService : Service() {
 
         val notification = NotificationCompat.Builder(this, FOREGROUND_NOTIFICATION_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_hearing_white)
-            .setContentTitle(getString(R.string.wake_service_foreground_notification))
+            .setContentTitle(
+                getString(
+                    if (wakeDevice.isHeyDicio()) R.string.wake_service_foreground_notification
+                    else R.string.wake_custom_service_foreground_notification
+                )
+            )
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)
             .setShowWhen(false)

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
@@ -58,7 +58,7 @@ class WakeService : Service() {
         if (MainActivity.isCreated <= 0) {
             // if the main activity is neither visible nor in the background,
             // then unload the STT after a while because it would be using resources uselessly
-            sttInputDevice.releaseResources()
+            sttInputDevice.reinitializeToReleaseResources()
         }
     }
 
@@ -120,7 +120,7 @@ class WakeService : Service() {
     override fun onDestroy() {
         listening.set(false)
         job.cancel()
-        wakeDevice.releaseResources()
+        wakeDevice.reinitializeToReleaseResources()
         super.onDestroy()
     }
 

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/WakeService.kt
@@ -27,6 +27,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import org.stypox.dicio.MainActivity
 import org.stypox.dicio.MainActivity.Companion.ACTION_WAKE_WORD
@@ -71,6 +72,15 @@ class WakeService : Service() {
     override fun onCreate() {
         super.onCreate()
         notificationManager = getSystemService(this, NotificationManager::class.java)!!
+
+        scope.launch {
+            // Recreate the notification so that it says the correct thing (i.e. there is a
+            // different string for the "Hey Dicio" wake word and for a custom one).
+            // Ignore the first one (i.e. the current value), which is handled in onStartCommand.
+            wakeDevice.isHeyDicio.drop(1).collect { isHeyDicio ->
+                createForegroundNotification(isHeyDicio)
+            }
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -80,7 +90,7 @@ class WakeService : Service() {
         }
 
         try {
-            createForegroundNotification()
+            createForegroundNotification(wakeDevice.isHeyDicio.value)
         } catch (t: Throwable) {
             stopWithMessage("could not create WakeService foreground notification", t)
             return START_NOT_STICKY
@@ -135,7 +145,7 @@ class WakeService : Service() {
         }
     }
 
-    private fun createForegroundNotification() {
+    private fun createForegroundNotification(isHeyDicio: Boolean) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
                 FOREGROUND_NOTIFICATION_CHANNEL_ID,
@@ -150,7 +160,7 @@ class WakeService : Service() {
             .setSmallIcon(R.drawable.ic_hearing_white)
             .setContentTitle(
                 getString(
-                    if (wakeDevice.isHeyDicio()) R.string.wake_service_foreground_notification
+                    if (isHeyDicio) R.string.wake_service_foreground_notification
                     else R.string.wake_custom_service_foreground_notification
                 )
             )

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
@@ -174,6 +174,8 @@ class OpenWakeWordDevice(
         scope.cancel()
     }
 
+    override fun isHeyDicio(): Boolean = !userWakeFile.exists()
+
     companion object {
         val TAG = OpenWakeWordDevice::class.simpleName
         const val MEL_URL = "https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/melspectrogram.tflite"

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
@@ -41,7 +41,6 @@ class OpenWakeWordDevice(
 
     private val audio = FloatArray(OwwModel.MEL_INPUT_COUNT)
     private var model: OwwModel? = null
-    private var needsReload: Boolean = false
 
     private val scope = CoroutineScope(Dispatchers.IO)
 
@@ -91,7 +90,6 @@ class OpenWakeWordDevice(
 
             try {
                 _state.value = WakeState.Loading
-                needsReload = false
                 model = OwwModel(
                     melFile.file,
                     embFile.file,

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
@@ -1,6 +1,7 @@
 package org.stypox.dicio.io.wake.oww
 
 import android.content.Context
+import android.net.Uri
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -9,14 +10,13 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import org.stypox.dicio.io.wake.WakeDevice
 import org.stypox.dicio.io.wake.WakeState
 import org.stypox.dicio.ui.util.Progress
 import org.stypox.dicio.util.FileToDownload
-import org.stypox.dicio.util.downloadBinaryFileWithPartial
 import org.stypox.dicio.util.downloadBinaryFilesWithPartial
-import org.stypox.dicio.util.getResponse
 import java.io.File
 import java.io.IOException
 
@@ -24,6 +24,7 @@ class OpenWakeWordDevice(
     @ApplicationContext appContext: Context,
     private val okHttpClient: OkHttpClient,
 ) : WakeDevice {
+    private val resolver = appContext.contentResolver
     private val _state: MutableStateFlow<WakeState>
     override val state: StateFlow<WakeState>
 
@@ -33,11 +34,16 @@ class OpenWakeWordDevice(
     private val embFile = FileToDownload(EMB_URL, File(owwFolder, "embedding.tflite"))
     private val wakeFile = FileToDownload(WAKE_URL, File(owwFolder, "wake.tflite"))
     private val allModelFiles = listOf(melFile, embFile, wakeFile)
+    private val userWakeFile = File(owwFolder, "userwake.tflite")
 
     private val audio = FloatArray(OwwModel.MEL_INPUT_COUNT)
     private var model: OwwModel? = null
+    private var needsReload: Boolean = false
 
     private val scope = CoroutineScope(Dispatchers.IO)
+
+    private val _hasUserWakeFile: MutableStateFlow<Boolean>
+    val hasUserWakeFile: StateFlow<Boolean>
 
     init {
         _state = if (allModelFiles.any(FileToDownload::needsToBeDownloaded)) {
@@ -46,6 +52,47 @@ class OpenWakeWordDevice(
             MutableStateFlow(WakeState.NotLoaded)
         }
         state = _state
+        _hasUserWakeFile = MutableStateFlow(userWakeFile.exists())
+        hasUserWakeFile = _hasUserWakeFile
+    }
+
+    suspend fun addUserWakeFile(source: Uri) {
+        // Use a partial file to ensure atomicity
+        withContext(Dispatchers.IO) {
+            val partialFile = File.createTempFile(userWakeFile.name, ".part", cacheDir)
+            val inputStream = resolver.openInputStream(source)
+            if (inputStream != null) {
+                inputStream.use { source ->
+                    partialFile.outputStream().use {
+                        source.copyTo(it)
+                    }
+                }
+
+                // Remove the previous file if it already exists
+                userWakeFile.delete()
+                val renameOk = partialFile.renameTo(userWakeFile)
+                _hasUserWakeFile.value = userWakeFile.exists()
+                if (!renameOk) {
+                    throw IOException("Cannot rename partial file $partialFile to actual file $userWakeFile")
+                }
+            }
+        }
+
+        // Force reload the model
+        needsReload = true
+    }
+
+    fun removeUserWakeFile() {
+        scope.launch {
+            // Use a partial file to ensure atomicity
+            withContext(Dispatchers.IO) {
+                userWakeFile.delete()
+                _hasUserWakeFile.value = userWakeFile.exists()
+            }
+
+            // Force reload the model
+            needsReload = true
+        }
     }
 
     override fun download() {
@@ -78,6 +125,16 @@ class OpenWakeWordDevice(
             )
         }
 
+        if (needsReload && (_state.value == WakeState.Loaded || _state.value is WakeState.ErrorLoading)) {
+            model!!.close()
+            model = null
+            _state.value = WakeState.NotLoaded
+        }
+
+        if (_state.value is WakeState.ErrorLoading) {
+            return false
+        }
+
         if (model == null) {
             if (_state.value != WakeState.NotLoaded) {
                 throw IOException("Model has not been downloaded yet")
@@ -85,11 +142,18 @@ class OpenWakeWordDevice(
 
             try {
                 _state.value = WakeState.Loading
-                model = OwwModel(melFile.file, embFile.file, wakeFile.file)
+                needsReload = false
+                model = OwwModel(
+                    melFile.file, embFile.file, if (userWakeFile.exists()) {
+                        userWakeFile
+                    } else {
+                        wakeFile.file
+                    }
+                )
                 _state.value = WakeState.Loaded
             } catch (t: Throwable) {
                 _state.value = WakeState.ErrorLoading(t)
-                throw t
+                return false
             }
         }
 

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
@@ -21,10 +21,9 @@ import java.io.File
 import java.io.IOException
 
 class OpenWakeWordDevice(
-    @ApplicationContext appContext: Context,
+    @ApplicationContext private val appContext: Context,
     private val okHttpClient: OkHttpClient,
 ) : WakeDevice {
-    private val resolver = appContext.contentResolver
     private val _state: MutableStateFlow<WakeState>
     override val state: StateFlow<WakeState>
 
@@ -33,17 +32,18 @@ class OpenWakeWordDevice(
     private val melFile = FileToDownload(MEL_URL, File(owwFolder, "melspectrogram.tflite"))
     private val embFile = FileToDownload(EMB_URL, File(owwFolder, "embedding.tflite"))
     private val wakeFile = FileToDownload(WAKE_URL, File(owwFolder, "wake.tflite"))
-    private val allModelFiles = listOf(melFile, embFile, wakeFile)
-    private val userWakeFile = File(owwFolder, "userwake.tflite")
+    private val userWakeFile = userWakeFile(appContext)
+    private val userWakeFileExists = userWakeFile.exists()
+    private val allModelFiles =
+        // wakeFile is not needed if we want to use the userWakeFile instead
+        if (userWakeFileExists) listOf(melFile, embFile)
+        else listOf(melFile, embFile, wakeFile)
 
     private val audio = FloatArray(OwwModel.MEL_INPUT_COUNT)
     private var model: OwwModel? = null
     private var needsReload: Boolean = false
 
     private val scope = CoroutineScope(Dispatchers.IO)
-
-    private val _hasUserWakeFile: MutableStateFlow<Boolean>
-    val hasUserWakeFile: StateFlow<Boolean>
 
     init {
         _state = if (allModelFiles.any(FileToDownload::needsToBeDownloaded)) {
@@ -52,47 +52,6 @@ class OpenWakeWordDevice(
             MutableStateFlow(WakeState.NotLoaded)
         }
         state = _state
-        _hasUserWakeFile = MutableStateFlow(userWakeFile.exists())
-        hasUserWakeFile = _hasUserWakeFile
-    }
-
-    suspend fun addUserWakeFile(source: Uri) {
-        // Use a partial file to ensure atomicity
-        withContext(Dispatchers.IO) {
-            val partialFile = File.createTempFile(userWakeFile.name, ".part", cacheDir)
-            val inputStream = resolver.openInputStream(source)
-            if (inputStream != null) {
-                inputStream.use { source ->
-                    partialFile.outputStream().use {
-                        source.copyTo(it)
-                    }
-                }
-
-                // Remove the previous file if it already exists
-                userWakeFile.delete()
-                val renameOk = partialFile.renameTo(userWakeFile)
-                _hasUserWakeFile.value = userWakeFile.exists()
-                if (!renameOk) {
-                    throw IOException("Cannot rename partial file $partialFile to actual file $userWakeFile")
-                }
-            }
-        }
-
-        // Force reload the model
-        needsReload = true
-    }
-
-    fun removeUserWakeFile() {
-        scope.launch {
-            // Use a partial file to ensure atomicity
-            withContext(Dispatchers.IO) {
-                userWakeFile.delete()
-                _hasUserWakeFile.value = userWakeFile.exists()
-            }
-
-            // Force reload the model
-            needsReload = true
-        }
     }
 
     override fun download() {
@@ -125,16 +84,6 @@ class OpenWakeWordDevice(
             )
         }
 
-        if (needsReload && (_state.value == WakeState.Loaded || _state.value is WakeState.ErrorLoading)) {
-            model!!.close()
-            model = null
-            _state.value = WakeState.NotLoaded
-        }
-
-        if (_state.value is WakeState.ErrorLoading) {
-            return false
-        }
-
         if (model == null) {
             if (_state.value != WakeState.NotLoaded) {
                 throw IOException("Model has not been downloaded yet")
@@ -144,11 +93,9 @@ class OpenWakeWordDevice(
                 _state.value = WakeState.Loading
                 needsReload = false
                 model = OwwModel(
-                    melFile.file, embFile.file, if (userWakeFile.exists()) {
-                        userWakeFile
-                    } else {
-                        wakeFile.file
-                    }
+                    melFile.file,
+                    embFile.file,
+                    if (userWakeFileExists) userWakeFile else wakeFile.file,
                 )
                 _state.value = WakeState.Loaded
             } catch (t: Throwable) {
@@ -174,12 +121,44 @@ class OpenWakeWordDevice(
         scope.cancel()
     }
 
-    override fun isHeyDicio(): Boolean = !userWakeFile.exists()
+    override fun isHeyDicio(): Boolean = !userWakeFileExists
 
     companion object {
         val TAG = OpenWakeWordDevice::class.simpleName
         const val MEL_URL = "https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/melspectrogram.tflite"
         const val EMB_URL = "https://github.com/dscripka/openWakeWord/releases/download/v0.5.1/embedding_model.tflite"
         const val WAKE_URL = "https://github.com/Stypox/dicio-android/releases/download/v2.0/hey_dicio_v6.0.tflite"
+
+        private fun userWakeFile(context: Context) =
+            File(context.filesDir, "openWakeWord/userwake.tflite")
+
+        suspend fun addUserWakeFile(context: Context, source: Uri) {
+            // Use a partial file to ensure atomicity
+            val userWakeFile = userWakeFile(context)
+            withContext(Dispatchers.IO) {
+                val partialFile = File.createTempFile(userWakeFile.name, ".part", context.cacheDir)
+                val inputStream = context.contentResolver.openInputStream(source)
+                if (inputStream != null) {
+                    inputStream.use { source ->
+                        partialFile.outputStream().use {
+                            source.copyTo(it)
+                        }
+                    }
+
+                    // Remove the previous file if it already exists
+                    userWakeFile.delete()
+                    val renameOk = partialFile.renameTo(userWakeFile)
+                    if (!renameOk) {
+                        throw IOException("Cannot rename partial file $partialFile to actual file $userWakeFile")
+                    }
+                }
+            }
+        }
+
+        suspend fun removeUserWakeFile(context: Context) {
+            withContext(Dispatchers.IO) {
+                userWakeFile(context).delete()
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OpenWakeWordDevice.kt
@@ -147,6 +147,7 @@ class OpenWakeWordDevice(
 
                     // Remove the previous file if it already exists
                     userWakeFile.delete()
+                    userWakeFile.parentFile?.mkdirs()
                     val renameOk = partialFile.renameTo(userWakeFile)
                     if (!renameOk) {
                         throw IOException("Cannot rename partial file $partialFile to actual file $userWakeFile")

--- a/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OwwModel.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/io/wake/oww/OwwModel.kt
@@ -99,17 +99,17 @@ class OwwModel(
 
     companion object {
         // mel model shape is [1,x] -> [1,1,floor((x-512)/160)+1,32]
-        const val MEL_INPUT_COUNT = 512 + 160 * 4; // chosen by us, 1152 samples @ 16kHz = 72ms
-        const val MEL_OUTPUT_COUNT = (MEL_INPUT_COUNT - 512) / 160 + 1; // formula obtained empirically
-        const val MEL_FEATURE_SIZE = 32; // also the size of features received by the emb model
+        const val MEL_INPUT_COUNT = 512 + 160 * 4 // chosen by us, 1152 samples @ 16kHz = 72ms
+        const val MEL_OUTPUT_COUNT = (MEL_INPUT_COUNT - 512) / 160 + 1 // formula obtained empirically
+        const val MEL_FEATURE_SIZE = 32 // also the size of features received by the emb model
 
         // emb model shape is [1,76,32,1] -> [1,1,1,96]
-        const val EMB_INPUT_COUNT = 76; // hardcoded in the model
-        const val EMB_OUTPUT_COUNT = 1;
-        const val EMB_FEATURE_SIZE = 96; // also the size of features received by the wake model
+        const val EMB_INPUT_COUNT = 76 // hardcoded in the model
+        const val EMB_OUTPUT_COUNT = 1
+        const val EMB_FEATURE_SIZE = 96 // also the size of features received by the wake model
 
         // wake model shape is [1,16,96] -> [1,1]
-        const val WAKE_INPUT_COUNT = 16; // hardcoded in the model
+        const val WAKE_INPUT_COUNT = 16 // hardcoded in the model
 
         private fun loadModel(modelPath: File, inputDims: IntArray? = null): Interpreter {
             val interpreter = Interpreter(modelPath)

--- a/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsScreen.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsScreen.kt
@@ -152,16 +152,16 @@ private fun MainSettingsScreen(
                 if (hasUserWakeFile) {
                     SettingsItem(
                         modifier = Modifier.clickable { viewModel.removeOwwUserWakeFile() },
-                        title = stringResource(R.string.pref_wakeword_custom_delete),
+                        title = stringResource(R.string.pref_wake_custom_delete),
                         icon = Icons.Default.DeleteSweep,
-                        description = stringResource(R.string.pref_wakeword_custom_delete_summary),
+                        description = stringResource(R.string.pref_wake_custom_delete_summary),
                     )
                 } else {
                     SettingsItem(
                         modifier = Modifier.clickable { importLauncher.launch(arrayOf("*/*")) },
-                        title = stringResource(R.string.pref_wakeword_custom_import),
+                        title = stringResource(R.string.pref_wake_custom_import),
                         icon = Icons.Default.UploadFile,
-                        description = stringResource(R.string.pref_wakeword_custom_import_summary),
+                        description = stringResource(R.string.pref_wake_custom_import_summary_oww),
                     )
                 }
             }

--- a/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.datastore.core.DataStore
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import org.stypox.dicio.di.WakeDeviceWrapper
 import org.stypox.dicio.io.wake.oww.OpenWakeWordDevice
@@ -22,7 +23,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MainSettingsViewModel @Inject constructor(
     application: Application,
-    private val wakeDeviceWrapper: WakeDeviceWrapper?,
+    wakeDeviceWrapper: WakeDeviceWrapper?,
     private val dataStore: DataStore<UserSettings>
 ) : AndroidViewModel(application) {
     // run blocking because the settings screen cannot start if settings have not been loaded yet
@@ -39,12 +40,17 @@ class MainSettingsViewModel @Inject constructor(
         }
     }
 
-    val openWakeWordDevice: OpenWakeWordDevice?
-        get() = wakeDeviceWrapper?.openWakeWordDevice
+    val wakeDevice = wakeDeviceWrapper?.currentDevice ?: MutableStateFlow(null)
 
-    fun addUserWakeFile(uri: Uri) {
+    fun addOwwUserWakeFile(uri: Uri) {
         viewModelScope.launch {
-            openWakeWordDevice?.addUserWakeFile(uri)
+            (wakeDevice.value as? OpenWakeWordDevice)?.addUserWakeFile(uri)
+        }
+    }
+
+    fun removeOwwUserWakeFile() {
+        viewModelScope.launch {
+            (wakeDevice.value as? OpenWakeWordDevice)?.removeUserWakeFile()
         }
     }
 

--- a/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsViewModel.kt
@@ -1,11 +1,14 @@
 package org.stypox.dicio.settings
 
 import android.app.Application
+import android.net.Uri
 import androidx.datastore.core.DataStore
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import org.stypox.dicio.di.WakeDeviceWrapper
+import org.stypox.dicio.io.wake.oww.OpenWakeWordDevice
 import org.stypox.dicio.settings.datastore.InputDevice
 import org.stypox.dicio.settings.datastore.Language
 import org.stypox.dicio.settings.datastore.SpeechOutputDevice
@@ -19,6 +22,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MainSettingsViewModel @Inject constructor(
     application: Application,
+    private val wakeDeviceWrapper: WakeDeviceWrapper?,
     private val dataStore: DataStore<UserSettings>
 ) : AndroidViewModel(application) {
     // run blocking because the settings screen cannot start if settings have not been loaded yet
@@ -32,6 +36,15 @@ class MainSettingsViewModel @Inject constructor(
                     .apply(transform)
                     .build()
             }
+        }
+    }
+
+    val openWakeWordDevice: OpenWakeWordDevice?
+        get() = wakeDeviceWrapper?.openWakeWordDevice
+
+    fun addUserWakeFile(uri: Uri) {
+        viewModelScope.launch {
+            openWakeWordDevice?.addUserWakeFile(uri)
         }
     }
 

--- a/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.stypox.dicio.di.WakeDeviceWrapper
 import org.stypox.dicio.io.wake.oww.OpenWakeWordDevice
@@ -23,7 +24,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MainSettingsViewModel @Inject constructor(
     application: Application,
-    wakeDeviceWrapper: WakeDeviceWrapper?,
+    private val wakeDeviceWrapper: WakeDeviceWrapper?,
     private val dataStore: DataStore<UserSettings>
 ) : AndroidViewModel(application) {
     // run blocking because the settings screen cannot start if settings have not been loaded yet
@@ -40,17 +41,19 @@ class MainSettingsViewModel @Inject constructor(
         }
     }
 
-    val wakeDevice = wakeDeviceWrapper?.currentDevice ?: MutableStateFlow(null)
+    val isHeyDicio: StateFlow<Boolean> = wakeDeviceWrapper?.isHeyDicio ?: MutableStateFlow(true)
 
     fun addOwwUserWakeFile(uri: Uri) {
         viewModelScope.launch {
-            (wakeDevice.value as? OpenWakeWordDevice)?.addUserWakeFile(uri)
+            OpenWakeWordDevice.addUserWakeFile(getApplication(), uri)
+            wakeDeviceWrapper?.reinitializeToReleaseResources()
         }
     }
 
     fun removeOwwUserWakeFile() {
         viewModelScope.launch {
-            (wakeDevice.value as? OpenWakeWordDevice)?.removeUserWakeFile()
+            OpenWakeWordDevice.removeUserWakeFile(getApplication())
+            wakeDeviceWrapper?.reinitializeToReleaseResources()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,10 +89,10 @@
     <string name="pref_wake_method_summary">Choose the service to use to listen for the \"Hey Dicio\" wakeup word in the background</string>
     <string name="pref_wake_method_disabled">Disabled</string>
     <string name="pref_wake_method_openwakeword">OpenWakeWord offline audio processing</string>
-    <string name="pref_wakeword_custom_delete">Delete custom wake word</string>
-    <string name="pref_wakeword_custom_delete_summary">Return to default \'Hey Dicio\' wake word.</string>
-    <string name="pref_wakeword_custom_import">Import custom wake word</string>
-    <string name="pref_wakeword_custom_import_summary">Use model from TFLite file instead of default \'Hey Dicio\' wake word.</string>
+    <string name="pref_wake_custom_delete">Delete custom wake word</string>
+    <string name="pref_wake_custom_delete_summary">Return to default \"Hey Dicio\" wake word</string>
+    <string name="pref_wake_custom_import">Import custom wake word</string>
+    <string name="pref_wake_custom_import_summary_oww">Replace the default \"Hey Dicio\" wake word with a custom TFLite model; you can download some custom models from github.com/dscripka/openWakeWord/releases</string>
     <string name="pref_skill_not_available">This skill is not yet available for your language. Contributions are welcome!</string>
     <string name="pref_skill_missing_permissions">Requires these permissions: %1$s</string>
     <string name="pref_skill_grant_permissions">Grant</string>
@@ -192,6 +192,7 @@
     <string name="wake_service_foreground_notification_summary">This notification allows the Dicio
         wake word service to listen to the microphone in the background</string>
     <string name="wake_service_foreground_notification">Listening for the \"Hey Dicio\" wake-up word</string>
+    <string name="wake_custom_service_foreground_notification">Listening for custom wake-up word</string>
     <string name="wake_service_start_notification">Tap to start Dicio wake word service</string>
     <string name="wake_service_triggered_notification">Dicio wake word triggered, tap to open</string>
     <string name="wake_service_start_notification_summary">In Android 11+ Dicio can\'t start the service without a manual interaction from the user.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,10 @@
     <string name="pref_wake_method_summary">Choose the service to use to listen for the \"Hey Dicio\" wakeup word in the background</string>
     <string name="pref_wake_method_disabled">Disabled</string>
     <string name="pref_wake_method_openwakeword">OpenWakeWord offline audio processing</string>
+    <string name="pref_wakeword_custom_delete">Delete custom wake word</string>
+    <string name="pref_wakeword_custom_delete_summary">Return to default \'Hey Dicio\' wake word.</string>
+    <string name="pref_wakeword_custom_import">Import custom wake word</string>
+    <string name="pref_wakeword_custom_import_summary">Use model from TFLite file instead of default \'Hey Dicio\' wake word.</string>
     <string name="pref_skill_not_available">This skill is not yet available for your language. Contributions are welcome!</string>
     <string name="pref_skill_missing_permissions">Requires these permissions: %1$s</string>
     <string name="pref_skill_grant_permissions">Grant</string>


### PR DESCRIPTION
While I can recompile Dicio myself to replace the wake word... it would be really nice if users could use a custom wake word more easily. This PR adds the ability to import a `.tflite` file to override the default downloaded "Hey Dicio" wake word.

Generating a custom wake word is out of scope for the app, but users can download a model from the [Home Assistant collection](https://github.com/fwartner/home-assistant-wakewords-collection) or use the OpenWakeWord scripts for training on Google Colab.

Fixes #289 #275 #238