### PR TITLE
Smarter fallback responses

### DIFF
--- a/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSkillEvaluator.kt
+++ b/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/FakeSkillEvaluator.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import org.dicio.skill.skill.Permission
 import org.stypox.dicio.eval.SkillEvaluator
 import org.stypox.dicio.io.input.InputEvent
-import org.stypox.dicio.ui.home.InteractionLog
+import org.dicio.skill.skill.InteractionLog
 
 class FakeSkillEvaluator : SkillEvaluator {
     override val state: MutableStateFlow<InteractionLog> = MutableStateFlow(

--- a/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/ScreenshotTakerTest.kt
+++ b/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/ScreenshotTakerTest.kt
@@ -44,9 +44,9 @@ import org.stypox.dicio.skills.timer.TimerInfo
 import org.stypox.dicio.skills.timer.TimerOutput
 import org.stypox.dicio.skills.weather.WeatherInfo
 import org.stypox.dicio.skills.weather.WeatherOutput
-import org.stypox.dicio.ui.home.Interaction
-import org.stypox.dicio.ui.home.InteractionLog
-import org.stypox.dicio.ui.home.QuestionAnswer
+import org.dicio.skill.skill.Interaction
+import org.dicio.skill.skill.InteractionLog
+import org.dicio.skill.skill.QuestionAnswer
 import org.stypox.dicio.io.input.SttState
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/app/src/main/kotlin/org/stypox/dicio/eval/SkillEvaluator.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/eval/SkillEvaluator.kt
@@ -18,10 +18,10 @@ import org.stypox.dicio.di.SttInputDeviceWrapper
 import org.stypox.dicio.io.graphical.ErrorSkillOutput
 import org.stypox.dicio.io.graphical.MissingPermissionsSkillOutput
 import org.stypox.dicio.io.input.InputEvent
-import org.stypox.dicio.ui.home.Interaction
-import org.stypox.dicio.ui.home.InteractionLog
-import org.stypox.dicio.ui.home.PendingQuestion
-import org.stypox.dicio.ui.home.QuestionAnswer
+import org.dicio.skill.skill.Interaction
+import org.dicio.skill.skill.InteractionLog
+import org.dicio.skill.skill.PendingQuestion
+import org.dicio.skill.skill.QuestionAnswer
 import javax.inject.Singleton
 
 interface SkillEvaluator {
@@ -148,6 +148,8 @@ class SkillEvaluatorImpl(
                 }
             } else {
                 skillRanker.addBatchToTop(nextSkills)
+            }
+            if (output.getKeepListening(skillContext)) {
                 skillContext.speechOutputDevice.runWhenFinishedSpeaking {
                     sttInputDevice.tryLoad(this::processInputEvent)
                 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackOutput.kt
@@ -5,7 +5,13 @@ import org.stypox.dicio.R
 import org.stypox.dicio.io.graphical.HeadlineSpeechSkillOutput
 import org.stypox.dicio.util.getString
 
-class TextFallbackOutput : HeadlineSpeechSkillOutput {
+class TextFallbackOutput(private val secondTime: Boolean) : HeadlineSpeechSkillOutput {
     override fun getSpeechOutput(ctx: SkillContext): String =
-        ctx.getString(R.string.eval_no_match)
+        if (secondTime) {
+            ctx.getString(R.string.eval_no_match_no_repeat)
+        } else {
+            ctx.getString(R.string.eval_no_match)
+        }
+
+    override fun getKeepListening(ctx: SkillContext): Boolean = !secondTime
 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackSkill.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackSkill.kt
@@ -8,6 +8,7 @@ import org.stypox.dicio.util.RecognizeEverythingSkill
 class TextFallbackSkill(correspondingSkillInfo: SkillInfo) :
     RecognizeEverythingSkill(correspondingSkillInfo) {
     override suspend fun generateOutput(ctx: SkillContext, inputData: String): SkillOutput {
-        return TextFallbackOutput()
+        val interactions = ctx.interactionLog.interactions
+        return TextFallbackOutput(secondTime = interactions.lastOrNull()?.questionsAnswers?.lastOrNull()?.answer is TextFallbackOutput)
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerOutput.kt
@@ -74,7 +74,7 @@ sealed interface TimerOutput : SkillOutput {
                 ): SkillOutput {
                     return if (inputData == null) {
                         // impossible situation
-                        TextFallbackOutput()
+                        TextFallbackOutput(true)
                     } else {
                         onGotDuration(inputData)
                     }

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/HomeScreen.kt
@@ -29,11 +29,11 @@ import dev.shreyaspatil.permissionflow.compose.rememberPermissionFlowRequestLaun
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.InteractionLog
 import org.dicio.skill.skill.Permission
 import org.dicio.skill.skill.SkillInfo
 import org.stypox.dicio.R
 import org.stypox.dicio.di.SkillContextImpl
-import org.stypox.dicio.eval.SkillEvaluator
 import org.stypox.dicio.io.input.InputEvent
 import org.stypox.dicio.io.input.SttState
 import org.stypox.dicio.io.wake.WakeState

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/InteractionComponents.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/InteractionComponents.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.InteractionLog
 import org.dicio.skill.skill.SkillInfo
 import org.dicio.skill.skill.SkillOutput
 import org.stypox.dicio.di.SkillContextImpl
@@ -118,7 +119,7 @@ fun InteractionList(
                     // (and therefore the error was not caused by the input, but e.g. by the STT)
                     countedItem(canBeAnchor = true) {
                         ConfirmedQuestionCard(
-                            userInput = it.question,
+                            userInput = it.question!!,
                             onClick = onConfirmedQuestionClick,
                         )
                     }
@@ -157,7 +158,7 @@ fun InteractionList(
                     )
                 }
                 countedItem(canBeAnchor = false) {
-                    LoadingAnswerCard(skill = pendingQuestion.skillBeingEvaluated)
+                    LoadingAnswerCard(skill = pendingQuestion.skillBeingEvaluated!!)
                 }
             }
         }

--- a/app/src/main/kotlin/org/stypox/dicio/ui/util/PreviewParameterProviders.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/util/PreviewParameterProviders.kt
@@ -24,10 +24,10 @@ import org.stypox.dicio.skills.telephone.TelephoneInfo
 import org.stypox.dicio.skills.timer.TimerInfo
 import org.stypox.dicio.skills.timer.TimerOutput
 import org.stypox.dicio.skills.weather.WeatherInfo
-import org.stypox.dicio.ui.home.Interaction
-import org.stypox.dicio.ui.home.InteractionLog
-import org.stypox.dicio.ui.home.PendingQuestion
-import org.stypox.dicio.ui.home.QuestionAnswer
+import org.dicio.skill.skill.Interaction
+import org.dicio.skill.skill.InteractionLog
+import org.dicio.skill.skill.PendingQuestion
+import org.dicio.skill.skill.QuestionAnswer
 import java.io.IOException
 
 
@@ -53,7 +53,7 @@ class SkillInfoPreviews : CollectionPreviewParameterProvider<SkillInfo>(listOf(
 ))
 
 class SkillOutputPreviews : CollectionPreviewParameterProvider<SkillOutput>(listOf(
-    TextFallbackOutput(),
+    TextFallbackOutput(false),
 ))
 
 class InteractionLogPreviews : CollectionPreviewParameterProvider<InteractionLog>(listOf(
@@ -88,7 +88,7 @@ class InteractionLogPreviews : CollectionPreviewParameterProvider<InteractionLog
             Interaction(
                 skill = TimerInfo,
                 questionsAnswers = listOf(
-                    QuestionAnswer("Set a timer", TimerOutput.SetAskDuration { TextFallbackOutput() })
+                    QuestionAnswer("Set a timer", TimerOutput.SetAskDuration { TextFallbackOutput(false) })
                 )
             )
         ),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,7 @@
     <string name="eval_network_error">Network error</string>
     <string name="eval_network_error_description">Dicio could not reach the internet. Please check your connection and retry.</string>
     <string name="eval_no_match">I did not understand, could you repeat?</string>
+    <string name="eval_no_match_no_repeat">I did not understand.</string>
     <string name="stt_say_something">Say something…</string>
     <string name="stt_did_not_understand">I could not understand, try again</string>
     <string name="stt_popup">Speech to text popup</string>

--- a/skill/src/main/java/org/dicio/skill/context/SkillContext.kt
+++ b/skill/src/main/java/org/dicio/skill/context/SkillContext.kt
@@ -2,6 +2,7 @@ package org.dicio.skill.context
 
 import android.content.Context
 import org.dicio.numbers.ParserFormatter
+import org.dicio.skill.skill.InteractionLog
 import java.util.Locale
 
 /**
@@ -40,4 +41,10 @@ interface SkillContext {
      * The [SpeechOutputDevice] that should be used for skill speech output.
      */
     val speechOutputDevice: SpeechOutputDevice
+
+    /**
+     * The [InteractionLog] that tracks the recent interactions with Dicio.
+     * Do not access this while building skills, or a circular dependency will be created.
+     */
+    val interactionLog: InteractionLog
 }

--- a/skill/src/main/java/org/dicio/skill/skill/InteractionData.kt
+++ b/skill/src/main/java/org/dicio/skill/skill/InteractionData.kt
@@ -1,7 +1,4 @@
-package org.stypox.dicio.ui.home
-
-import org.dicio.skill.skill.SkillInfo
-import org.dicio.skill.skill.SkillOutput
+package org.dicio.skill.skill
 
 data class QuestionAnswer(
     val question: String?,

--- a/skill/src/main/java/org/dicio/skill/skill/SkillOutput.kt
+++ b/skill/src/main/java/org/dicio/skill/skill/SkillOutput.kt
@@ -10,4 +10,6 @@ interface SkillOutput {
 
     @Composable
     fun GraphicalOutput(ctx: SkillContext)
+
+    fun getKeepListening(ctx: SkillContext): Boolean = getNextSkills(ctx).isNotEmpty()
 }


### PR DESCRIPTION
This PR makes the fallback skill re-enable the microphone one time when the user says something that it can't understand. Of course, it's possible that the speech that Dicio is hearing is not directed at it, so it doesn't make sense to retry indefinitely: if the user's second attempt is also something that Dicio can't understand, this implementation omits the "Could you repeat?" part of the response and stops re-enabling the microphone until the user successfully performs another interaction.

Fixes #280.

I'm not totally happy about the fact that this PR requires me to move InteractionLog into the skill/ module, but I didn't see another good solution.