### PR TITLE
Smarter fallback responses 3

### DIFF
--- a/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/ScreenshotTakerTest.kt
+++ b/app/src/androidTest/kotlin/org/stypox/dicio/screenshot/ScreenshotTakerTest.kt
@@ -286,7 +286,7 @@ class ScreenshotTakerTest {
                             url = "https://github.com/TeamNewPipe/NewPipe",
                             thumbnailUrl = "https://external-content.duckduckgo.com/ip3/github.com.ico"
                         ),
-                    ))
+                    ), askAgain = false)
                 ),
             )),
         ), null)

--- a/app/src/main/kotlin/org/stypox/dicio/di/SkillContextImpl.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/SkillContextImpl.kt
@@ -4,8 +4,8 @@ import android.annotation.SuppressLint
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import org.dicio.numbers.ParserFormatter
-import org.dicio.skill.context.SkillContext
 import org.dicio.skill.context.SpeechOutputDevice
+import org.dicio.skill.skill.SkillOutput
 import org.stypox.dicio.io.speech.NothingSpeechDevice
 import java.util.Locale
 import javax.inject.Inject
@@ -18,7 +18,7 @@ class SkillContextImpl private constructor(
     // this constructor can take any SpeechOutputDevice to allow newForPreviews to provide
     // NothingSpeechDevice
     override val speechOutputDevice: SpeechOutputDevice,
-) : SkillContext {
+) : SkillContextInternal {
 
     @Inject
     constructor(
@@ -50,6 +50,8 @@ class SkillContextImpl private constructor(
 
             return lastParserFormatter?.first
         }
+
+    override var previousOutput: SkillOutput? = null
 
     companion object {
         fun newForPreviews(context: Context): SkillContextImpl {

--- a/app/src/main/kotlin/org/stypox/dicio/di/SkillContextInternal.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/SkillContextInternal.kt
@@ -1,0 +1,9 @@
+package org.stypox.dicio.di
+
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.SkillOutput
+
+interface SkillContextInternal : SkillContext {
+    // allows modifying this value
+    override var previousOutput: SkillOutput?
+}

--- a/app/src/main/kotlin/org/stypox/dicio/di/SkillContextModule.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/di/SkillContextModule.kt
@@ -4,9 +4,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import org.dicio.skill.context.SkillContext
-import org.stypox.dicio.io.input.SttInputDevice
-import org.stypox.dicio.io.input.vosk.VoskInputDevice
 import javax.inject.Singleton
 
 @Module
@@ -14,5 +11,6 @@ import javax.inject.Singleton
 class SkillContextModule {
     @Provides
     @Singleton
-    fun provideSkillContext(skillContextImpl: SkillContextImpl): SkillContext = skillContextImpl
+    fun provideSkillContext(skillContextImpl: SkillContextImpl): SkillContextInternal =
+        skillContextImpl
 }

--- a/app/src/main/kotlin/org/stypox/dicio/eval/SkillHandler.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/eval/SkillHandler.kt
@@ -15,6 +15,7 @@ import org.dicio.skill.skill.Skill
 import org.dicio.skill.skill.SkillInfo
 import org.stypox.dicio.di.LocaleManager
 import org.stypox.dicio.di.SkillContextImpl
+import org.stypox.dicio.di.SkillContextInternal
 import org.stypox.dicio.settings.datastore.UserSettings
 import org.stypox.dicio.settings.datastore.UserSettingsModule
 import org.stypox.dicio.skills.calculator.CalculatorInfo
@@ -35,7 +36,7 @@ import javax.inject.Singleton
 class SkillHandler @Inject constructor(
     private val dataStore: DataStore<UserSettings>,
     private val localeManager: LocaleManager,
-    private val skillContext: SkillContext,
+    private val skillContext: SkillContextInternal,
 ) {
     // TODO improve id handling (maybe just use an int that can point to an Android resource)
     val allSkillInfoList = listOf(

--- a/app/src/main/kotlin/org/stypox/dicio/eval/SkillRanker.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/eval/SkillRanker.kt
@@ -88,7 +88,9 @@ class SkillRanker(
     }
 
     fun removeTopBatch() {
-        batches.pop()
+        if (!batches.isEmpty()) {
+            batches.pop()
+        }
     }
 
     fun removeAllBatches() {

--- a/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.dicio.skill.context.SkillContext
 import org.dicio.skill.skill.SkillInfo
+import org.stypox.dicio.di.SkillContextInternal
 import org.stypox.dicio.settings.datastore.UserSettings
 import org.stypox.dicio.eval.SkillHandler
 import org.stypox.dicio.util.toStateFlowDistinctBlockingFirst
@@ -19,7 +20,7 @@ import javax.inject.Inject
 class SkillSettingsViewModel @Inject constructor(
     application: Application,
     private val dataStore: DataStore<UserSettings>,
-    val skillContext: SkillContext,
+    val skillContext: SkillContextInternal,
     private val skillHandler: SkillHandler,
 ) : AndroidViewModel(application) {
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackOutput.kt
@@ -1,11 +1,39 @@
 package org.stypox.dicio.skills.fallback.text
 
 import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.AlwaysWorstScore
+import org.dicio.skill.skill.Skill
+import org.dicio.skill.skill.SkillOutput
+import org.dicio.skill.skill.Specificity
 import org.stypox.dicio.R
 import org.stypox.dicio.io.graphical.HeadlineSpeechSkillOutput
 import org.stypox.dicio.util.getString
 
-class TextFallbackOutput : HeadlineSpeechSkillOutput {
-    override fun getSpeechOutput(ctx: SkillContext): String =
-        ctx.getString(R.string.eval_no_match)
+class TextFallbackOutput(
+    val askToRepeat: Boolean
+) : HeadlineSpeechSkillOutput {
+    override fun getSpeechOutput(ctx: SkillContext): String = ctx.getString(
+        if (askToRepeat) R.string.eval_no_match_repeat
+        else R.string.eval_no_match
+    )
+
+    // this makes it so that the evaluator will open the microphone again, but the skill provided
+    // will never actually match, so the previous batch of skills will be used instead
+    override fun getNextSkills(ctx: SkillContext): List<Skill<*>> =
+        if (askToRepeat)
+            listOf(
+                object : Skill<Unit>(TextFallbackInfo, Specificity.LOW) {
+                    override fun score(ctx: SkillContext, input: String) = Pair(AlwaysWorstScore, Unit)
+
+                    override suspend fun generateOutput(
+                        ctx: SkillContext,
+                        inputData: Unit
+                    ): SkillOutput {
+                        // impossible situation, since AlwaysWorstScore was used above
+                        throw RuntimeException("AlwaysWorstScore still triggered generateOutput")
+                    }
+                }
+            )
+        else
+            listOf()
 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackOutput.kt
@@ -1,10 +1,7 @@
 package org.stypox.dicio.skills.fallback.text
 
 import org.dicio.skill.context.SkillContext
-import org.dicio.skill.skill.AlwaysWorstScore
-import org.dicio.skill.skill.Skill
-import org.dicio.skill.skill.SkillOutput
-import org.dicio.skill.skill.Specificity
+import org.dicio.skill.skill.InteractionPlan
 import org.stypox.dicio.R
 import org.stypox.dicio.io.graphical.HeadlineSpeechSkillOutput
 import org.stypox.dicio.util.getString
@@ -19,21 +16,6 @@ class TextFallbackOutput(
 
     // this makes it so that the evaluator will open the microphone again, but the skill provided
     // will never actually match, so the previous batch of skills will be used instead
-    override fun getNextSkills(ctx: SkillContext): List<Skill<*>> =
-        if (askToRepeat)
-            listOf(
-                object : Skill<Unit>(TextFallbackInfo, Specificity.LOW) {
-                    override fun score(ctx: SkillContext, input: String) = Pair(AlwaysWorstScore, Unit)
-
-                    override suspend fun generateOutput(
-                        ctx: SkillContext,
-                        inputData: Unit
-                    ): SkillOutput {
-                        // impossible situation, since AlwaysWorstScore was used above
-                        throw RuntimeException("AlwaysWorstScore still triggered generateOutput")
-                    }
-                }
-            )
-        else
-            listOf()
+    override fun getInteractionPlan(ctx: SkillContext) =
+        InteractionPlan.Continue(reopenMicrophone = askToRepeat)
 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackSkill.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/TextFallbackSkill.kt
@@ -8,6 +8,10 @@ import org.stypox.dicio.util.RecognizeEverythingSkill
 class TextFallbackSkill(correspondingSkillInfo: SkillInfo) :
     RecognizeEverythingSkill(correspondingSkillInfo) {
     override suspend fun generateOutput(ctx: SkillContext, inputData: String): SkillOutput {
-        return TextFallbackOutput()
+        return TextFallbackOutput(
+            // we ask to repeat only if we have not asked already just in the previous interaction
+            askToRepeat = (ctx.previousOutput as? TextFallbackOutput)?.let { !it.askToRepeat }
+                ?: true
+        )
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/telephone/TelephoneOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/telephone/TelephoneOutput.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.dicio.skill.skill.Skill
 import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.InteractionPlan
 import org.dicio.skill.skill.SkillOutput
 import org.stypox.dicio.R
 import org.stypox.dicio.io.graphical.Headline
@@ -25,8 +26,8 @@ class TelephoneOutput(
         ctx.getString(R.string.skill_telephone_found_contacts, contacts.size)
     }
 
-    override fun getNextSkills(ctx: SkillContext): List<Skill<*>> {
-        val result = mutableListOf<Skill<*>>(
+    override fun getInteractionPlan(ctx: SkillContext): InteractionPlan {
+        val nextSkills = mutableListOf<Skill<*>>(
             ContactChooserName(
                 // when saying the name, there is no way to distinguish between
                 // different numbers, so just use the first one
@@ -35,7 +36,7 @@ class TelephoneOutput(
         )
 
         if (ctx.parserFormatter != null) {
-            result.add(
+            nextSkills.add(
                 ContactChooserIndex(
                     contacts.flatMap { contact ->
                         contact.second.map { number ->
@@ -46,7 +47,10 @@ class TelephoneOutput(
             )
         }
 
-        return result
+        return InteractionPlan.StartSubInteraction(
+            reopenMicrophone = true,
+            nextSkills = nextSkills,
+        )
     }
 
     @Composable

--- a/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerOutput.kt
@@ -5,18 +5,17 @@ import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LongState
 import org.dicio.numbers.ParserFormatter
-import org.dicio.skill.skill.Skill
 import org.dicio.skill.context.SkillContext
 import org.dicio.skill.skill.AlwaysBestScore
 import org.dicio.skill.skill.AlwaysWorstScore
 import org.dicio.skill.skill.Score
+import org.dicio.skill.skill.Skill
 import org.dicio.skill.skill.SkillOutput
 import org.dicio.skill.skill.Specificity
 import org.stypox.dicio.R
 import org.stypox.dicio.io.graphical.Headline
 import org.stypox.dicio.io.graphical.HeadlineSpeechSkillOutput
 import org.stypox.dicio.sentences.Sentences
-import org.stypox.dicio.skills.fallback.text.TextFallbackOutput
 import org.stypox.dicio.util.RecognizeYesNoSkill
 import org.stypox.dicio.util.getString
 import java.text.DecimalFormatSymbols
@@ -73,8 +72,8 @@ sealed interface TimerOutput : SkillOutput {
                     inputData: Duration?
                 ): SkillOutput {
                     return if (inputData == null) {
-                        // impossible situation
-                        TextFallbackOutput()
+                        // impossible situation, since AlwaysWorstScore was used above
+                        throw RuntimeException("AlwaysWorstScore still triggered generateOutput")
                     } else {
                         onGotDuration(inputData)
                     }

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/HomeScreenViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import org.dicio.skill.context.SkillContext
+import org.stypox.dicio.di.SkillContextInternal
 import org.stypox.dicio.di.SpeechOutputDeviceWrapper
 import org.stypox.dicio.di.SttInputDeviceWrapper
 import org.stypox.dicio.di.WakeDeviceWrapper
@@ -25,7 +26,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeScreenViewModel @Inject constructor(
     application: Application,
-    val skillContext: SkillContext,
+    val skillContext: SkillContextInternal,
     val skillHandler: SkillHandler,
     val dataStore: DataStore<UserSettings>,
     val sttInputDevice: SttInputDeviceWrapper,

--- a/app/src/main/kotlin/org/stypox/dicio/ui/util/PreviewParameterProviders.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/util/PreviewParameterProviders.kt
@@ -53,7 +53,7 @@ class SkillInfoPreviews : CollectionPreviewParameterProvider<SkillInfo>(listOf(
 ))
 
 class SkillOutputPreviews : CollectionPreviewParameterProvider<SkillOutput>(listOf(
-    TextFallbackOutput(),
+    TextFallbackOutput(askToRepeat = true),
 ))
 
 class InteractionLogPreviews : CollectionPreviewParameterProvider<InteractionLog>(listOf(
@@ -88,7 +88,10 @@ class InteractionLogPreviews : CollectionPreviewParameterProvider<InteractionLog
             Interaction(
                 skill = TimerInfo,
                 questionsAnswers = listOf(
-                    QuestionAnswer("Set a timer", TimerOutput.SetAskDuration { TextFallbackOutput() })
+                    QuestionAnswer(
+                        "Set a timer",
+                        TimerOutput.SetAskDuration { TextFallbackOutput(askToRepeat = true) }
+                    )
                 )
             )
         ),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,7 +116,8 @@
     <string name="eval_fatal_error">Could not evaluate your request</string>
     <string name="eval_network_error">Network error</string>
     <string name="eval_network_error_description">Dicio could not reach the internet. Please check your connection and retry.</string>
-    <string name="eval_no_match">I did not understand, could you repeat?</string>
+    <string name="eval_no_match">I did not understand</string>
+    <string name="eval_no_match_repeat">Could you repeat?</string>
     <string name="stt_say_something">Say something…</string>
     <string name="stt_did_not_understand">I could not understand, try again</string>
     <string name="stt_popup">Speech to text popup</string>

--- a/app/src/test/kotlin/org/stypox/dicio/Mocks.kt
+++ b/app/src/test/kotlin/org/stypox/dicio/Mocks.kt
@@ -10,6 +10,7 @@ import org.dicio.skill.skill.FloatScore
 import org.dicio.skill.skill.Score
 import org.dicio.skill.skill.Skill
 import org.dicio.skill.skill.SkillInfo
+import org.dicio.skill.skill.SkillOutput
 import org.dicio.skill.skill.Specificity
 import java.util.Locale
 
@@ -19,6 +20,7 @@ object MockSkillContext : SkillContext {
     override val sentencesLanguage: String get() = mocked()
     override val parserFormatter: ParserFormatter get() = mocked()
     override val speechOutputDevice: SpeechOutputDevice get() = mocked()
+    override val previousOutput: SkillOutput = mocked()
 }
 
 object MockSkillInfo : SkillInfo("") {

--- a/skill/src/main/java/org/dicio/skill/context/SkillContext.kt
+++ b/skill/src/main/java/org/dicio/skill/context/SkillContext.kt
@@ -2,6 +2,7 @@ package org.dicio.skill.context
 
 import android.content.Context
 import org.dicio.numbers.ParserFormatter
+import org.dicio.skill.skill.SkillOutput
 import java.util.Locale
 
 /**
@@ -40,4 +41,9 @@ interface SkillContext {
      * The [SpeechOutputDevice] that should be used for skill speech output.
      */
     val speechOutputDevice: SpeechOutputDevice
+
+    /**
+     * The previous output belonging to the same interaction.
+     */
+    val previousOutput: SkillOutput?
 }

--- a/skill/src/main/java/org/dicio/skill/skill/InteractionPlan.kt
+++ b/skill/src/main/java/org/dicio/skill/skill/InteractionPlan.kt
@@ -1,0 +1,49 @@
+package org.dicio.skill.skill
+
+sealed interface InteractionPlan {
+    /**
+     * Whether to start the microphone after the speech output from [SkillOutput.getSpeechOutput]
+     * finishes being spoken
+     */
+    val reopenMicrophone: Boolean
+
+    /**
+     * Considers the current interaction as finished, resetting the skill evaluator to the state it
+     * was when the app was opened, i.e. removes all `nextSkills` from the stack of batches
+     */
+    data object FinishInteraction : InteractionPlan {
+        override val reopenMicrophone = false
+    }
+
+    /**
+     * Removes the top batch of `nextSkills` but keeps the rest of the stack of batches intact
+     */
+    data class FinishSubInteraction(
+        override val reopenMicrophone: Boolean
+    ) : InteractionPlan
+
+    /**
+     * Continues with the current batches of `nextSkills`, without modifying the stack of batches
+     */
+    data class Continue(
+        override val reopenMicrophone: Boolean
+    ) : InteractionPlan
+
+    /**
+     * Removes the `nextSkills` at the top of the stack of batches (if there is any) and adds
+     * [nextSkills]
+     */
+    data class ReplaceSubInteraction(
+        override val reopenMicrophone: Boolean,
+        val nextSkills: List<Skill<*>>
+    ) : InteractionPlan
+
+    /**
+     * Adds [nextSkills] to the stack of batches, effectively starting a new (sub-) interaction
+     * because the `nextSkills` at the top of the stack have priority over others
+     */
+    data class StartSubInteraction(
+        override val reopenMicrophone: Boolean,
+        val nextSkills: List<Skill<*>>
+    ) : InteractionPlan
+}

--- a/skill/src/main/java/org/dicio/skill/skill/SkillOutput.kt
+++ b/skill/src/main/java/org/dicio/skill/skill/SkillOutput.kt
@@ -6,7 +6,7 @@ import org.dicio.skill.context.SkillContext
 interface SkillOutput {
     fun getSpeechOutput(ctx: SkillContext): String
 
-    fun getNextSkills(ctx: SkillContext): List<Skill<*>> = listOf()
+    fun getInteractionPlan(ctx: SkillContext): InteractionPlan = InteractionPlan.FinishInteraction
 
     @Composable
     fun GraphicalOutput(ctx: SkillContext)

--- a/skill/src/test/java/org/dicio/skill/Mocks.kt
+++ b/skill/src/test/java/org/dicio/skill/Mocks.kt
@@ -19,6 +19,7 @@ object MockSkillContext : SkillContext {
     override val sentencesLanguage: String get() = mocked()
     override val parserFormatter: ParserFormatter get() = mocked()
     override val speechOutputDevice: SpeechOutputDevice get() = mocked()
+    override val previousOutput: SkillOutput = mocked()
 }
 
 object MockSkillInfo : SkillInfo("") {


### PR DESCRIPTION
Another spin at #292 which is a bit better than my attempt in #295. As explained in #292:

> Of course, it's possible that the speech that Dicio is hearing is not directed at it, so it doesn't make sense to retry indefinitely: if the user's second attempt is also something that Dicio can't understand, this implementation omits the "Could you repeat?" part of the response and stops re-enabling the microphone until the user successfully performs another interaction.

In order to make this possible, two architectural changes were needed:
- Allowing the fallback skill to check if it was triggered on the previous execution, too. This can be done by adding a new field to `SkillContext`:
  - in #292 it was `InteractionLog`
  - in #295 it was a boolean `previousInteractionWasFallback`
  - in this PR it's the previous `SkillOutput`.
- Communicating to `SkillEvaluator` that the microphone should be enabled again
  - in #292 this was done by adding a `getKeepListening()` function to `SkillOutput`
  - in #295 there were no architectural changes, but the text fallback skill returned an unmatchable skill in `getNextSkills()`, which still made `SkillEvaluator` think the skill was requesting more output
  - in this PR `SkillOutput.getNextSkills()` is renamed to `getInteractionPlan()` with various options on how the interaction should continue (see the sealed class `InteractionPlan`), which also includes whether the microphone should be reenabled immediately or not
  
Fixes #280
Testing APK: https://github.com/Stypox/testing-apks/releases/download/12/app-debug.apk