### PR TITLE
Change naming for Debug Builds.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,7 +48,11 @@ android {
 
     buildTypes {
         debug {
-            applicationIdSuffix = ".debug"
+            var normalizedGitBranch = gitBranch().replaceFirst("^[^A-Za-z]+", "").replace(Regex("[^0-9A-Za-z]+"), "")
+            applicationIdSuffix = ".$normalizedGitBranch"
+            versionNameSuffix = "-$normalizedGitBranch"
+
+            resValue("string", "app_name", "Dicio-${gitBranch()}")
         }
         release {
             isMinifyEnabled = false
@@ -194,5 +198,16 @@ dependencies {
 configurations.configureEach {
     resolutionStrategy {
         force(libs.test.core)
+    }
+}
+
+fun gitBranch(): String {
+    return try {
+        providers.exec {
+            commandLine("git", "rev-parse", "--abbrev-ref", "HEAD")
+        }.standardOutput.asText.get().trim()
+    } catch (e: Exception) {
+        logger.warn("Git isn't installed, using default name for debug app.")
+        "debug"
     }
 }


### PR DESCRIPTION
I don't have access to an emulator currently, so I add debug apps to my phone. Occasionally, I will lose my sanity trying to differentiate between the three versions of Dicio. This pr adds distinct app names, ID's and tags to the debug builds. In addition, for someone installing and using a debug build on their phone (because they are too impatient to wait for a release, me again :grin:) , this is useful. Thanks!