### PR TITLE
Add content description to few missing places

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsScreen.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -209,7 +210,13 @@ private fun SkillSettingsItemHeader(
 
     Row(
         modifier = Modifier
-            .let { if (toggleExpanded != null) it.clickable(onClick = toggleExpanded) else it }
+            .let { it ->
+                if (toggleExpanded != null)
+                    it.clickable(onClick = toggleExpanded)
+                else
+                    // still group items together for better accessibility
+                    it.semantics(mergeDescendants = true) {}
+            }
             .padding(4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -220,7 +227,8 @@ private fun SkillSettingsItemHeader(
         }
         Icon(
             painter = skill.icon(),
-            contentDescription = skill.name(LocalContext.current),
+            // no content description here as it would be duplicate with the text below
+            contentDescription = null,
             modifier = Modifier
                 .padding(start = 12.dp)
                 .size(24.dp),

--- a/app/src/main/kotlin/org/stypox/dicio/settings/ui/SettingsItem.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/ui/SettingsItem.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
@@ -40,12 +41,14 @@ fun SettingsItem(
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .semantics(mergeDescendants = true) {},
     ) {
         if (icon != null) {
             Icon(
                 imageVector = icon,
-                contentDescription = title,
+                // no content description here as it would be duplicate with the text below
+                contentDescription = null,
             )
             Spacer(modifier = Modifier.width(24.dp))
         }

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/HomeScreen.kt
@@ -146,7 +146,7 @@ fun HomeScreen(
                 searchIcon = {
                     Icon(
                         imageVector = Icons.Default.QuestionAnswer,
-                        contentDescription = null,
+                        contentDescription = stringResource(R.string.text_input_hint),
                     )
                 },
                 navigationIcon = navigationIcon,

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -61,12 +62,12 @@ private fun SkillRow(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier.semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
             painter = skill.icon(),
-            contentDescription = skill.name(LocalContext.current),
+            contentDescription = null,
             modifier = Modifier.size(36.dp)
         )
         Spacer(modifier = Modifier.width(12.dp))

--- a/app/src/main/kotlin/org/stypox/dicio/ui/nav/Drawer.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/nav/Drawer.kt
@@ -95,6 +95,7 @@ private fun DrawerHeader(modifier: Modifier = Modifier) {
                     text = stringResource(R.string.app_name),
                     style = MaterialTheme.typography.headlineMedium,
                     color = MaterialTheme.colorScheme.onPrimary,
+                    maxLines = 1,
                 )
                 Text(
                     text = stringResource(R.string.drawer_header_subtitle),

--- a/app/src/main/kotlin/org/stypox/dicio/ui/nav/Drawer.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/nav/Drawer.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -81,7 +82,7 @@ private fun DrawerHeader(modifier: Modifier = Modifier) {
     Surface(
         shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.primary,
-        modifier = modifier
+        modifier = modifier.clearAndSetSemantics {}
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/kotlin/org/stypox/dicio/ui/nav/Navigation.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/nav/Navigation.kt
@@ -11,10 +11,12 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.launch
+import org.stypox.dicio.R
 import org.stypox.dicio.io.input.stt_popup.SttPopupActivity
 import org.stypox.dicio.settings.MainSettingsScreen
 import org.stypox.dicio.settings.SkillSettingsScreen
@@ -29,7 +31,7 @@ fun Navigation() {
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = null,
+                contentDescription = stringResource(R.string.back),
             )
         }
     }


### PR DESCRIPTION
Addresses points 1 and 2 of issue #325.

I am not sure how to handle point 3 yet, there are too many buttons around the app and most of them already explain what is supposed to happen when you tap on them, so adding onClick semantics feels redundant. For example, I think it's better if, when the microphone button is focused, the talkback said "Start listening button, double tap to activate" instead of "Start listening button, double tap to start listening". The latter feels redundant. https://github.com/zhou-zhoukang can you help me pinpoint in which places it would be helpful to add `onClick` semantics?

Debug APK: https://github.com/Stypox/testing-apks/releases/download/16/app-debug.apk