### PR TITLE
Condense main menu + add skill categories

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsScreen.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/SkillSettingsScreen.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import dev.shreyaspatil.permissionflow.compose.rememberPermissionFlowRequestLauncher
+import java.text.Collator
+import java.util.Locale
 import org.dicio.skill.skill.SkillInfo
 import org.stypox.dicio.R
 import org.stypox.dicio.di.SkillContextImpl
@@ -87,8 +89,31 @@ fun SkillSettingsScreen(
     viewModel: SkillSettingsViewModel,
     modifier: Modifier = Modifier,
 ) {
+    val context = LocalContext.current
     val skills = viewModel.skills
     val enabledSkills by viewModel.enabledSkills.collectAsState()
+
+    // Get current locale for proper collation
+    val locale = context.resources.configuration.locales.get(0) ?: Locale.getDefault()
+    val collator = Collator.getInstance(locale)
+
+    // Group skills by category and sort
+    val categorizedSkills = skills
+        .groupBy { skill ->
+            val categoryRes = skill.categoryNameRes
+            if (categoryRes == 0) {
+                context.getString(R.string.category_other)
+            } else {
+                context.getString(categoryRes)
+            }
+        }
+        .mapValues { (_, skillsList) ->
+            // Sort skills alphabetically by localized name within each category
+            skillsList.sortedWith(compareBy(collator) { it.name(context) })
+        }
+        .toList()
+        // Sort categories alphabetically by localized name
+        .sortedWith(compareBy(collator) { it.first })
 
     LazyColumn(
         contentPadding = PaddingValues(top = 4.dp, bottom = 4.dp),
@@ -96,10 +121,10 @@ fun SkillSettingsScreen(
     ) {
         if (viewModel.numberLibraryNotAvailable) {
             item {
-                val context = LocalContext.current
+                val ctx = LocalContext.current
                 Card(
                     modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                    onClick = { ShareUtils.openUrlInBrowser(context, DICIO_NUMBERS_LINK) },
+                    onClick = { ShareUtils.openUrlInBrowser(ctx, DICIO_NUMBERS_LINK) },
                 ) {
                     Text(
                         text = stringResource(R.string.pref_skill_number_library_not_available),
@@ -112,13 +137,29 @@ fun SkillSettingsScreen(
                 }
             }
         }
-        items(skills) { skill ->
-            SkillSettingsItem(
-                skill = skill,
-                isAvailable = skill.isAvailable(viewModel.skillContext),
-                enabled = enabledSkills.getOrDefault(skill.id, true),
-                setEnabled = { enabled -> viewModel.setSkillEnabled(skill.id, enabled) }
-            )
+        
+        // Display skills grouped by category
+        for ((category, categorySkills) in categorizedSkills) {
+            item(key = "category_header_$category") {
+                Text(
+                    text = category,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
+                )
+            }
+            
+            items(categorySkills, key = { it.id }) { skill ->
+                SkillSettingsItem(
+                    skill = skill,
+                    isAvailable = skill.isAvailable(viewModel.skillContext),
+                    enabled = enabledSkills.getOrDefault(skill.id, true),
+                    setEnabled = { enabled -> viewModel.setSkillEnabled(skill.id, enabled) }
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/calculator/CalculatorInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/calculator/CalculatorInfo.kt
@@ -12,7 +12,7 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object CalculatorInfo : SkillInfo("calculator") {
-    override val categoryNameRes = R.string.category_productivity
+    override val categoryNameRes = R.string.category_utilities
 
     override fun name(context: Context) =
         context.getString(R.string.skill_name_calculator)

--- a/app/src/main/kotlin/org/stypox/dicio/skills/calculator/CalculatorInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/calculator/CalculatorInfo.kt
@@ -12,6 +12,8 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object CalculatorInfo : SkillInfo("calculator") {
+    override val categoryNameRes = R.string.category_productivity
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_calculator)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/current_time/CurrentTimeInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/current_time/CurrentTimeInfo.kt
@@ -12,6 +12,8 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object CurrentTimeInfo : SkillInfo("current_time") {
+    override val categoryNameRes = R.string.category_information
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_current_time)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/joke/JokeInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/joke/JokeInfo.kt
@@ -13,6 +13,8 @@ import org.stypox.dicio.sentences.Sentences
 import org.stypox.dicio.util.LocaleUtils
 
 object JokeInfo : SkillInfo("Joke") {
+    override val categoryNameRes = R.string.category_entertainment
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_joke)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/listening/ListeningInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/listening/ListeningInfo.kt
@@ -16,7 +16,7 @@ import org.stypox.dicio.settings.datastore.UserSettings
 class ListeningInfo(
     val dataStore: DataStore<UserSettings>,
 ) : SkillInfo("listening") {
-    override val categoryNameRes = R.string.category_other
+    override val categoryNameRes = R.string.category_utilities
 
     override fun name(context: Context) =
         context.getString(R.string.skill_name_listening)

--- a/app/src/main/kotlin/org/stypox/dicio/skills/listening/ListeningInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/listening/ListeningInfo.kt
@@ -16,6 +16,8 @@ import org.stypox.dicio.settings.datastore.UserSettings
 class ListeningInfo(
     val dataStore: DataStore<UserSettings>,
 ) : SkillInfo("listening") {
+    override val categoryNameRes = R.string.category_other
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_listening)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/lyrics/LyricsInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/lyrics/LyricsInfo.kt
@@ -12,6 +12,8 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object LyricsInfo : SkillInfo("lyrics") {
+    override val categoryNameRes = R.string.category_media
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_lyrics)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/media/MediaInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/media/MediaInfo.kt
@@ -12,6 +12,8 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object MediaInfo : SkillInfo("media") {
+    override val categoryNameRes = R.string.category_media
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_media)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/navigation/NavigationInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/navigation/NavigationInfo.kt
@@ -15,6 +15,8 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object NavigationInfo : SkillInfo("navigation") {
+    override val categoryNameRes = R.string.category_productivity
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_navigation)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/open/OpenInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/open/OpenInfo.kt
@@ -15,7 +15,7 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object OpenInfo : SkillInfo("open") {
-    override val categoryNameRes = R.string.category_productivity
+    override val categoryNameRes = R.string.category_utilities
 
     override fun name(context: Context) =
         context.getString(R.string.skill_name_open)

--- a/app/src/main/kotlin/org/stypox/dicio/skills/open/OpenInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/open/OpenInfo.kt
@@ -15,6 +15,8 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object OpenInfo : SkillInfo("open") {
+    override val categoryNameRes = R.string.category_productivity
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_open)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/search/SearchInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/search/SearchInfo.kt
@@ -12,6 +12,8 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object SearchInfo : SkillInfo("search") {
+    override val categoryNameRes = R.string.category_information
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_search)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/telephone/TelephoneInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/telephone/TelephoneInfo.kt
@@ -18,6 +18,8 @@ import org.stypox.dicio.util.PERMISSION_CALL_PHONE
 import org.stypox.dicio.util.PERMISSION_READ_CONTACTS
 
 object TelephoneInfo : SkillInfo("telephone") {
+    override val categoryNameRes = R.string.category_communication
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_telephone)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/timer/TimerInfo.kt
@@ -14,6 +14,8 @@ import org.stypox.dicio.R
 import org.stypox.dicio.sentences.Sentences
 
 object TimerInfo : SkillInfo("timer") {
+    override val categoryNameRes = R.string.category_productivity
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_timer)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/translation/TranslationInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/translation/TranslationInfo.kt
@@ -13,6 +13,8 @@ import org.stypox.dicio.sentences.Sentences
 import org.stypox.dicio.util.LocaleUtils
 
 object TranslationInfo : SkillInfo("translation") {
+    override val categoryNameRes = R.string.category_communication
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_translation)
 

--- a/app/src/main/kotlin/org/stypox/dicio/skills/weather/WeatherInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/weather/WeatherInfo.kt
@@ -25,6 +25,8 @@ import org.stypox.dicio.settings.ui.ListSetting
 import org.stypox.dicio.settings.ui.StringSetting
 
 object WeatherInfo : SkillInfo("weather") {
+    override val categoryNameRes = R.string.category_information
+
     override fun name(context: Context) =
         context.getString(R.string.skill_name_weather)
 

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
@@ -33,11 +33,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import java.text.Collator
+import java.util.Locale
 import org.dicio.skill.skill.SkillInfo
 import org.stypox.dicio.R
 import org.stypox.dicio.eval.SkillHandler
@@ -46,13 +49,35 @@ import org.stypox.dicio.ui.util.SkillInfoPreviews
 
 @Composable
 fun WhatICanDo(skills: List<SkillInfo>) {
+    val context = LocalContext.current
     var expanded by rememberSaveable { mutableStateOf(false) }
+    
+    // Get current locale for proper collation
+    val locale = context.resources.configuration.locales.get(0) ?: Locale.getDefault()
+    val collator = Collator.getInstance(locale)
+    
+    // Group skills by category and sort
+    val categorizedSkills = skills
+        .groupBy { skill ->
+            val categoryRes = skill.categoryNameRes
+            if (categoryRes == 0) {
+                context.getString(R.string.category_other)
+            } else {
+                context.getString(categoryRes)
+            }
+        }
+        .mapValues { (_, skillsList) ->
+            // Sort skills alphabetically by localized name within each category
+            skillsList.sortedWith(compareBy(collator) { it.name(context) })
+        }
+        .toList()
+        // Sort categories alphabetically by localized name
+        .sortedWith(compareBy(collator) { it.first })
     
     MessageCard(containerColor = MaterialTheme.colorScheme.secondaryContainer) {
         Column(modifier = Modifier.animateContentSize()) {
             if (skills.isEmpty()) {
                 NoEnabledSkills()
-
             } else {
                 // Collapsible header
                 WhatICanDoHeader(
@@ -60,12 +85,12 @@ fun WhatICanDo(skills: List<SkillInfo>) {
                     toggleExpanded = { expanded = !expanded }
                 )
 
-                // Conditionally show skills list when expanded
+                // Conditionally show categories when expanded
                 if (expanded) {
-                    for (skill in skills) {
-                        SkillRow(
-                            skill = skill,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    for ((category, categorySkills) in categorizedSkills) {
+                        CategorySection(
+                            categoryName = category,
+                            skills = categorySkills
                         )
                     }
                     Spacer(modifier = Modifier.height(8.dp))
@@ -107,6 +132,78 @@ private fun WhatICanDoHeader(
             modifier = Modifier
                 .rotate(expandedAnimation)
                 .size(24.dp),
+            imageVector = Icons.Default.ArrowDropDown,
+            contentDescription = stringResource(
+                if (expanded) R.string.reduce else R.string.expand
+            )
+        )
+    }
+}
+
+@Composable
+private fun CategorySection(
+    categoryName: String,
+    skills: List<SkillInfo>
+) {
+    var expanded by rememberSaveable(categoryName) { mutableStateOf(false) }
+    
+    Column(modifier = Modifier.animateContentSize()) {
+        // Category header
+        CategoryHeader(
+            categoryName = categoryName,
+            skillCount = skills.size,
+            expanded = expanded,
+            toggleExpanded = { expanded = !expanded }
+        )
+
+        // Conditionally show skills list when expanded
+        if (expanded) {
+            for (skill in skills) {
+                SkillRow(
+                    skill = skill,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryHeader(
+    categoryName: String,
+    skillCount: Int,
+    expanded: Boolean,
+    toggleExpanded: () -> Unit,
+) {
+    val expandedAnimation by animateFloatAsState(
+        label = "category_expanded_$categoryName",
+        targetValue = if (expanded) 180f else 0f,
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = toggleExpanded)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = categoryName,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.secondary,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = stringResource(R.string.skills_count, skillCount),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+            )
+        }
+        Icon(
+            modifier = Modifier
+                .rotate(expandedAnimation)
+                .size(20.dp),
             imageVector = Icons.Default.ArrowDropDown,
             contentDescription = stringResource(
                 if (expanded) R.string.reduce else R.string.expand

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
@@ -120,7 +120,6 @@ private fun CategorySection(
     var expanded by rememberSaveable(categoryName) { mutableStateOf(false) }
     
     Column(modifier = Modifier.animateContentSize()) {
-        // Category header
         CategoryHeader(
             categoryName = categoryName,
             skillCount = skills.size,
@@ -128,7 +127,6 @@ private fun CategorySection(
             toggleExpanded = { expanded = !expanded }
         )
 
-        // Conditionally show skills list when expanded
         if (expanded) {
             for (skill in skills) {
                 SkillRow(

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -50,7 +49,6 @@ import org.stypox.dicio.ui.util.SkillInfoPreviews
 @Composable
 fun WhatICanDo(skills: List<SkillInfo>) {
     val context = LocalContext.current
-    var expanded by rememberSaveable { mutableStateOf(false) }
     
     // Get current locale for proper collation
     val locale = context.resources.configuration.locales.get(0) ?: Locale.getDefault()
@@ -75,67 +73,41 @@ fun WhatICanDo(skills: List<SkillInfo>) {
         .sortedWith(compareBy(collator) { it.first })
     
     MessageCard(containerColor = MaterialTheme.colorScheme.secondaryContainer) {
-        Column(modifier = Modifier.animateContentSize()) {
+        Column {
             if (skills.isEmpty()) {
                 NoEnabledSkills()
             } else {
-                // Collapsible header
-                WhatICanDoHeader(
-                    expanded = expanded,
-                    toggleExpanded = { expanded = !expanded }
-                )
+                // Header
+                WhatICanDoHeader()
 
-                // Conditionally show categories when expanded
-                if (expanded) {
-                    for ((category, categorySkills) in categorizedSkills) {
-                        CategorySection(
-                            categoryName = category,
-                            skills = categorySkills
-                        )
-                    }
-                    Spacer(modifier = Modifier.height(8.dp))
+                // Show all categories
+                for ((category, categorySkills) in categorizedSkills) {
+                    CategorySection(
+                        categoryName = category,
+                        skills = categorySkills
+                    )
                 }
+                Spacer(modifier = Modifier.height(8.dp))
             }
         }
     }
 }
 
 @Composable
-private fun WhatICanDoHeader(
-    expanded: Boolean,
-    toggleExpanded: () -> Unit,
-) {
-    val expandedAnimation by animateFloatAsState(
-        label = "what_i_can_do_expanded",
-        targetValue = if (expanded) 180f else 0f,
-    )
-
-    Row(
+private fun WhatICanDoHeader() {
+    Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = toggleExpanded)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
+            .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = stringResource(R.string.ready_to_help),
-                style = MaterialTheme.typography.headlineMedium,
-            )
-            Text(
-                text = stringResource(R.string.here_is_what_i_can_do),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
-            )
-        }
-        Icon(
-            modifier = Modifier
-                .rotate(expandedAnimation)
-                .size(24.dp),
-            imageVector = Icons.Default.ArrowDropDown,
-            contentDescription = stringResource(
-                if (expanded) R.string.reduce else R.string.expand
-            )
+        Text(
+            text = stringResource(R.string.ready_to_help),
+            style = MaterialTheme.typography.headlineMedium,
+        )
+        Text(
+            text = stringResource(R.string.here_is_what_i_can_do),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
         )
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/ui/home/WhatICanDo.kt
@@ -1,5 +1,8 @@
 package org.stypox.dicio.ui.home
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -11,13 +14,21 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -35,28 +46,72 @@ import org.stypox.dicio.ui.util.SkillInfoPreviews
 
 @Composable
 fun WhatICanDo(skills: List<SkillInfo>) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    
     MessageCard(containerColor = MaterialTheme.colorScheme.secondaryContainer) {
-        if (skills.isEmpty()) {
-            NoEnabledSkills()
+        Column(modifier = Modifier.animateContentSize()) {
+            if (skills.isEmpty()) {
+                NoEnabledSkills()
 
-        } else {
+            } else {
+                // Collapsible header
+                WhatICanDoHeader(
+                    expanded = expanded,
+                    toggleExpanded = { expanded = !expanded }
+                )
+
+                // Conditionally show skills list when expanded
+                if (expanded) {
+                    for (skill in skills) {
+                        SkillRow(
+                            skill = skill,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WhatICanDoHeader(
+    expanded: Boolean,
+    toggleExpanded: () -> Unit,
+) {
+    val expandedAnimation by animateFloatAsState(
+        label = "what_i_can_do_expanded",
+        targetValue = if (expanded) 180f else 0f,
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = toggleExpanded)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.ready_to_help),
+                style = MaterialTheme.typography.headlineMedium,
+            )
             Text(
                 text = stringResource(R.string.here_is_what_i_can_do),
-                style = MaterialTheme.typography.headlineMedium,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
             )
-
-            for (skill in skills) {
-                SkillRow(
-                    skill = skill,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                )
-            }
-            Spacer(modifier = Modifier.height(8.dp))
         }
+        Icon(
+            modifier = Modifier
+                .rotate(expandedAnimation)
+                .size(24.dp),
+            imageVector = Icons.Default.ArrowDropDown,
+            contentDescription = stringResource(
+                if (expanded) R.string.reduce else R.string.expand
+            )
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="category_media">Media</string>
     <string name="category_other">Other</string>
     <string name="category_productivity">Productivity</string>
+    <string name="category_utilities">Utilities</string>
     <!-- settings_header -->
     <string name="pref_io">Input and output methods</string>
     <string name="pref_general">General</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
     <string name="start_listening">Start listening</string>
     <string name="downloaded">Downloaded</string>
     <string name="loaded">Loaded</string>
+    <string name="ready_to_help">Ready to help!</string>
     <string name="here_is_what_i_can_do">Here is what I can do!</string>
     <string name="all_skills_disabled_title">All skills are disabled</string>
     <string name="all_skills_disabled_description">Please enable some skills from settings, otherwise Dicio will not be able to do anything</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="start_listening">Start listening</string>
     <string name="downloaded">Downloaded</string>
     <string name="loaded">Loaded</string>
-    <string name="ready_to_help">Ready to help!</string>
+    <string name="ready_to_help">Hi, how can I help?</string>
     <string name="here_is_what_i_can_do">Here is what I can do!</string>
     <string name="all_skills_disabled_title">All skills are disabled</string>
     <string name="all_skills_disabled_description">Please enable some skills from settings, otherwise Dicio will not be able to do anything</string>
@@ -59,12 +59,20 @@
     <string name="error_report_notification_toast">An error occurred, see the notification</string>
     <string name="error_report_channel_name">Error report notification</string>
     <string name="error_report_channel_description">Notifications to report errors</string>
+    <!-- Category Names -->
+    <string name="category_communication">Communication</string>
+    <string name="category_entertainment">Entertainment</string>
+    <string name="category_information">Information</string>
+    <string name="category_media">Media</string>
+    <string name="category_other">Other</string>
+    <string name="category_productivity">Productivity</string>
     <!-- settings_header -->
     <string name="pref_io">Input and output methods</string>
     <string name="pref_general">General</string>
     <string name="pref_appearance">Appearance</string>
     <string name="pref_skills_title">Skills</string>
     <string name="pref_skills_summary">Enable/disable skills and tune their behavior</string>
+    <string name="skills_count">%1$d skills</string>
     <string name="expand">Expand</string>
     <string name="reduce">Reduce</string>
     <string name="pref_theme">Theme</string>

--- a/app/src/main/sentences/skill_definitions.yml
+++ b/app/src/main/sentences/skill_definitions.yml
@@ -11,6 +11,7 @@ skills:
         captures:
           - id: calculation
             type: string
+            
   - id: calculator_operators
     specificity: low
     sentences:

--- a/skill/src/main/java/org/dicio/skill/skill/SkillInfo.kt
+++ b/skill/src/main/java/org/dicio/skill/skill/SkillInfo.kt
@@ -35,6 +35,14 @@ abstract class SkillInfo(
     abstract fun icon(): Painter
 
     /**
+     * The category this skill belongs to for organizational purposes. This is used to group
+     * skills on the main screen and in settings. Override this to assign a skill to a specific
+     * category. If not overridden, skills will be placed in the "Other" category.
+     * @return the string resource ID for the skill's category name (e.g. R.string.category_productivity)
+     */
+    open val categoryNameRes: Int = 0 // Will default to R.string.category_other in app module
+
+    /**
      * Provides all of the permissions this skill needs in order to run. For example, the telephone
      * skill needs the `CALL_PHONE` and `READ_CONTACTS` permissions to run. The
      * permissions expressed here will be requested to the user when the skill is first used, or


### PR DESCRIPTION
Made WhatICanDo.kt collapsible on main app screen.

Added categories for skills. These are used to categorize skills in the What I Can Do card and Skill Settings. Skill names are translatable via strings.xml and uses a collator to properly alphabetize categories based on the localized category names. Skills lacking a category are handled by dropping them into the Other category. 

Categories are assigned in the SkillInfo.kt files. Example from current_time:

```
object CurrentTimeInfo : SkillInfo("current_time") {
    override val categoryNameRes = R.string.category_information
```