### PR TITLE
Add SMS message skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Currently Dicio answers questions about:
 - **open**: opens an app on your device - _Open NewPipe_
 - **calculator**: evaluates basic calculations - _What is four thousand and two times three minus a million divided by three hundred?_
 - **telephone**: view and call contacts - _Call Tom_
+- **sms**: send SMS messages to contacts - _Send a text to Jenna saying I got us reservations for dinner_
 - **timer**: set, query and cancel timers - _Set a timer for five minutes_
 - **current time**: query current time - _What time is it?_
 - **navigation**: opens the navigation app at the requested position - _Take me to New York, fifteenth avenue_

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 
+    <!-- the sms skill needs to send text messages -->
+    <uses-permission android:name="android.permission.SEND_SMS" />
+
     <!-- allowBackup=false because of a critical nasty bug: https://medium.com/p/924c91bafcac -->
     <application
         android:name=".App"

--- a/app/src/main/kotlin/org/stypox/dicio/eval/SkillHandler.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/eval/SkillHandler.kt
@@ -26,6 +26,7 @@ import org.stypox.dicio.skills.media.MediaInfo
 import org.stypox.dicio.skills.navigation.NavigationInfo
 import org.stypox.dicio.skills.open.OpenInfo
 import org.stypox.dicio.skills.search.SearchInfo
+import org.stypox.dicio.skills.sms.SmsInfo
 import org.stypox.dicio.skills.telephone.TelephoneInfo
 import org.stypox.dicio.skills.timer.TimerInfo
 import org.stypox.dicio.skills.translation.TranslationInfo
@@ -49,6 +50,7 @@ class SkillHandler @Inject constructor(
         CalculatorInfo,
         NavigationInfo,
         TelephoneInfo,
+        SmsInfo,
         TimerInfo,
         CurrentTimeInfo,
         MediaInfo,

--- a/app/src/main/kotlin/org/stypox/dicio/skills/sms/AskMessageOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/sms/AskMessageOutput.kt
@@ -1,0 +1,64 @@
+package org.stypox.dicio.skills.sms
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.AlwaysBestScore
+import org.dicio.skill.skill.AlwaysWorstScore
+import org.dicio.skill.skill.InteractionPlan
+import org.dicio.skill.skill.Score
+import org.dicio.skill.skill.Skill
+import org.dicio.skill.skill.SkillOutput
+import org.dicio.skill.skill.Specificity
+import org.stypox.dicio.R
+import org.stypox.dicio.io.graphical.Body
+import org.stypox.dicio.io.graphical.Headline
+import org.stypox.dicio.util.getString
+
+class AskMessageOutput(
+    private val name: String,
+    private val number: String
+) : SkillOutput {
+    override fun getSpeechOutput(ctx: SkillContext): String =
+        ctx.getString(R.string.skill_sms_what_message)
+
+    override fun getInteractionPlan(ctx: SkillContext): InteractionPlan {
+        val messageSkill = object : Skill<String>(SmsInfo, Specificity.HIGH) {
+            override fun score(
+                ctx: SkillContext,
+                input: String
+            ): Pair<Score, String> {
+                val trimmedInput = input.trim()
+                return Pair(
+                    if (trimmedInput.isEmpty()) AlwaysWorstScore else AlwaysBestScore,
+                    trimmedInput
+                )
+            }
+
+            override suspend fun generateOutput(
+                ctx: SkillContext,
+                inputData: String
+            ): SkillOutput {
+                return ConfirmSmsOutput(name, number, inputData)
+            }
+        }
+
+        return InteractionPlan.StartSubInteraction(
+            reopenMicrophone = true,
+            nextSkills = listOf(messageSkill),
+        )
+    }
+
+    @Composable
+    override fun GraphicalOutput(ctx: SkillContext) {
+        Column {
+            Headline(text = getSpeechOutput(ctx))
+            Spacer(modifier = Modifier.height(4.dp))
+            Body(text = "$name ($number)")
+        }
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/sms/ConfirmSmsOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/sms/ConfirmSmsOutput.kt
@@ -1,0 +1,57 @@
+package org.stypox.dicio.skills.sms
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.InteractionPlan
+import org.dicio.skill.skill.SkillOutput
+import org.stypox.dicio.R
+import org.stypox.dicio.io.graphical.Body
+import org.stypox.dicio.io.graphical.Headline
+import org.stypox.dicio.sentences.Sentences
+import org.stypox.dicio.util.RecognizeYesNoSkill
+import org.stypox.dicio.util.getString
+
+class ConfirmSmsOutput(
+    private val name: String,
+    private val number: String,
+    private val message: String
+) : SkillOutput {
+    override fun getSpeechOutput(ctx: SkillContext): String =
+        ctx.getString(R.string.skill_sms_confirm, message, name)
+
+    override fun getInteractionPlan(ctx: SkillContext): InteractionPlan {
+        val yesNoSentences = Sentences.UtilYesNo[ctx.sentencesLanguage]!!
+        val confirmYesNoSkill = object : RecognizeYesNoSkill(SmsInfo, yesNoSentences) {
+            override suspend fun generateOutput(
+                ctx: SkillContext,
+                inputData: Boolean
+            ): SkillOutput {
+                return if (inputData) {
+                    SmsSkill.sendSms(number, message)
+                    SentSmsOutput(name, number, message)
+                } else {
+                    SentSmsOutput(null, null, null)
+                }
+            }
+        }
+
+        return InteractionPlan.ReplaceSubInteraction(
+            reopenMicrophone = true,
+            nextSkills = listOf(confirmYesNoSkill),
+        )
+    }
+
+    @Composable
+    override fun GraphicalOutput(ctx: SkillContext) {
+        Column {
+            Headline(text = getSpeechOutput(ctx))
+            Spacer(modifier = Modifier.height(4.dp))
+            Body(text = "$name ($number)")
+        }
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/sms/SentSmsOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/sms/SentSmsOutput.kt
@@ -1,0 +1,44 @@
+package org.stypox.dicio.skills.sms
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.SkillOutput
+import org.stypox.dicio.R
+import org.stypox.dicio.io.graphical.Body
+import org.stypox.dicio.io.graphical.Headline
+import org.stypox.dicio.util.getString
+
+class SentSmsOutput(
+    private val name: String?,
+    private val number: String?,
+    private val message: String?
+) : SkillOutput {
+    override fun getSpeechOutput(ctx: SkillContext): String = if (name == null) {
+        ctx.getString(R.string.skill_sms_not_sending)
+    } else {
+        "" // do not speak anything since the message was sent
+    }
+
+    @Composable
+    override fun GraphicalOutput(ctx: SkillContext) {
+        if (name == null) {
+            Headline(text = stringResource(R.string.skill_sms_not_sending))
+        } else {
+            Column {
+                Headline(text = stringResource(R.string.skill_sms_sent, name))
+                Spacer(modifier = Modifier.height(4.dp))
+                Body(text = number ?: "")
+                if (message != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Body(text = "\"$message\"")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsContactChooserIndex.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsContactChooserIndex.kt
@@ -1,0 +1,48 @@
+package org.stypox.dicio.skills.sms
+
+import org.dicio.numbers.unit.Number
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.AlwaysBestScore
+import org.dicio.skill.skill.AlwaysWorstScore
+import org.dicio.skill.skill.Score
+import org.dicio.skill.skill.Skill
+import org.dicio.skill.skill.SkillOutput
+import org.dicio.skill.skill.Specificity
+
+class SmsContactChooserIndex internal constructor(
+    private val contacts: List<Pair<String, String>>,
+    private val messageText: String?
+) : Skill<Int>(SmsInfo, Specificity.HIGH) {
+
+    override fun score(
+        ctx: SkillContext,
+        input: String
+    ): Pair<Score, Int> {
+        val index = ctx.parserFormatter!!
+            .extractNumber(input)
+            .preferOrdinal(true)
+            .mixedWithText
+            .asSequence()
+            .filter { obj -> (obj as? Number)?.isInteger == true }
+            .map { obj -> (obj as Number).integerValue().toInt() }
+            .firstOrNull() ?: 0
+        return Pair(
+            if (index <= 0 || index > contacts.size) AlwaysWorstScore else AlwaysBestScore,
+            index
+        )
+    }
+
+    override suspend fun generateOutput(ctx: SkillContext, inputData: Int): SkillOutput {
+        if (inputData > 0 && inputData <= contacts.size) {
+            val contact = contacts[inputData - 1]
+            return if (messageText == null) {
+                AskMessageOutput(contact.first, contact.second)
+            } else {
+                ConfirmSmsOutput(contact.first, contact.second, messageText)
+            }
+        } else {
+            // impossible situation
+            return SentSmsOutput(null, null, null)
+        }
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsContactChooserName.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsContactChooserName.kt
@@ -1,0 +1,51 @@
+package org.stypox.dicio.skills.sms
+
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.AlwaysBestScore
+import org.dicio.skill.skill.AlwaysWorstScore
+import org.dicio.skill.skill.Score
+import org.dicio.skill.skill.Skill
+import org.dicio.skill.skill.SkillOutput
+import org.dicio.skill.skill.Specificity
+import org.stypox.dicio.util.StringUtils
+
+class SmsContactChooserName internal constructor(
+    private val contacts: List<Pair<String, String>>,
+    private val messageText: String?
+) : Skill<Pair<String, String>?>(SmsInfo, Specificity.LOW) {
+
+    override fun score(
+        ctx: SkillContext,
+        input: String
+    ): Pair<Score, Pair<String, String>?> {
+        val trimmedInput = input.trim { it <= ' ' }
+
+        val bestContact = contacts
+            .map { nameNumberPair ->
+                Pair(
+                    nameNumberPair,
+                    StringUtils.contactStringDistance(trimmedInput, nameNumberPair.first)
+                )
+            }
+            .filter { pair -> pair.second < -7 }
+            .minByOrNull { a -> a.second }
+            ?.first
+
+        return Pair(
+            if (bestContact == null) AlwaysWorstScore else AlwaysBestScore,
+            bestContact
+        )
+    }
+
+    override suspend fun generateOutput(ctx: SkillContext, inputData: Pair<String, String>?): SkillOutput {
+        return inputData?.let {
+            if (messageText == null) {
+                AskMessageOutput(it.first, it.second)
+            } else {
+                ConfirmSmsOutput(it.first, it.second, messageText)
+            }
+        }
+            // impossible situation
+            ?: SentSmsOutput(null, null, null)
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsInfo.kt
@@ -1,0 +1,39 @@
+package org.stypox.dicio.skills.sms
+
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Message
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.Permission
+import org.dicio.skill.skill.Skill
+import org.dicio.skill.skill.SkillInfo
+import org.stypox.dicio.R
+import org.stypox.dicio.sentences.Sentences
+import org.stypox.dicio.util.PERMISSION_READ_CONTACTS
+import org.stypox.dicio.util.PERMISSION_SEND_SMS
+
+object SmsInfo : SkillInfo("sms") {
+    override fun name(context: Context) =
+        context.getString(R.string.skill_name_sms)
+
+    override fun sentenceExample(context: Context) =
+        context.getString(R.string.skill_sentence_example_sms)
+
+    @Composable
+    override fun icon() =
+        rememberVectorPainter(Icons.Default.Message)
+
+    override val neededPermissions: List<Permission>
+        = listOf(PERMISSION_READ_CONTACTS, PERMISSION_SEND_SMS)
+
+    override fun isAvailable(ctx: SkillContext): Boolean {
+        return Sentences.Sms[ctx.sentencesLanguage] != null &&
+                Sentences.UtilYesNo[ctx.sentencesLanguage] != null
+    }
+
+    override fun build(ctx: SkillContext): Skill<*> {
+        return SmsSkill(SmsInfo, Sentences.Sms[ctx.sentencesLanguage]!!)
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsOutput.kt
@@ -1,0 +1,88 @@
+package org.stypox.dicio.skills.sms
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.InteractionPlan
+import org.dicio.skill.skill.Skill
+import org.dicio.skill.skill.SkillOutput
+import org.stypox.dicio.R
+import org.stypox.dicio.io.graphical.Headline
+import org.stypox.dicio.skills.telephone.ContactChooserIndex
+import org.stypox.dicio.skills.telephone.ContactChooserName
+import org.stypox.dicio.util.getString
+
+class SmsOutput(
+    private val contacts: List<Pair<String, List<String>>>,
+    private val messageText: String?,
+) : SkillOutput {
+    override fun getSpeechOutput(ctx: SkillContext): String = if (contacts.isEmpty()) {
+        ctx.getString(R.string.skill_sms_unknown_contact)
+    } else {
+        ctx.getString(R.string.skill_sms_found_contacts, contacts.size)
+    }
+
+    override fun getInteractionPlan(ctx: SkillContext): InteractionPlan {
+        val nextSkills = mutableListOf<Skill<*>>(
+            SmsContactChooserName(
+                // when saying the name, there is no way to distinguish between
+                // different numbers, so just use the first one
+                contacts.map { Pair(it.first, it.second[0]) },
+                messageText
+            )
+        )
+
+        if (ctx.parserFormatter != null) {
+            nextSkills.add(
+                SmsContactChooserIndex(
+                    contacts.flatMap { contact ->
+                        contact.second.map { number ->
+                            Pair(contact.first, number)
+                        }
+                    },
+                    messageText
+                )
+            )
+        }
+
+        return InteractionPlan.StartSubInteraction(
+            reopenMicrophone = true,
+            nextSkills = nextSkills,
+        )
+    }
+
+    @Composable
+    override fun GraphicalOutput(ctx: SkillContext) {
+        if (contacts.isEmpty()) {
+            Headline(text = getSpeechOutput(ctx))
+        } else {
+            Column {
+                for (i in contacts.indices) {
+                    if (i != 0) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
+
+                    Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                        Text(
+                            text = "${i + 1}. ${contacts[i].first}",
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        for (number in contacts[i].second) {
+                            Text(
+                                text = number,
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsSkill.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/sms/SmsSkill.kt
@@ -1,0 +1,79 @@
+package org.stypox.dicio.skills.sms
+
+import android.telephony.SmsManager
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.SkillInfo
+import org.dicio.skill.skill.SkillOutput
+import org.dicio.skill.standard.StandardRecognizerData
+import org.dicio.skill.standard.StandardRecognizerSkill
+import org.stypox.dicio.sentences.Sentences.Sms
+import org.stypox.dicio.skills.telephone.Contact
+
+class SmsSkill(correspondingSkillInfo: SkillInfo, data: StandardRecognizerData<Sms>) :
+    StandardRecognizerSkill<Sms>(correspondingSkillInfo, data) {
+
+    override suspend fun generateOutput(ctx: SkillContext, inputData: Sms): SkillOutput {
+        val contentResolver = ctx.android.contentResolver
+        val (userContactName, messageText) = when (inputData) {
+            is Sms.Send -> Pair(
+                inputData.who?.trim { it <= ' ' } ?: "",
+                inputData.what?.trim()
+            )
+        }
+        
+        val contacts = Contact.getFilteredSortedContacts(contentResolver, userContactName)
+        val validContacts = ArrayList<Pair<String, List<String>>>()
+        
+        var i = 0
+        while (validContacts.size < 5 && i < contacts.size) {
+            val contact = contacts[i]
+            val numbers = contact.getNumbers(contentResolver)
+            if (numbers.isEmpty()) {
+                ++i
+                continue
+            }
+            if (validContacts.isEmpty()
+                && contact.distance < 3
+                && numbers.size == 1 // it has just one number
+                && (contacts.size <= i + 1 // the next contact has a distance higher by 3+
+                        || contacts[i + 1].distance - 2 > contact.distance)
+            ) {
+                // very close match with just one number and without distance ties
+                return if (messageText == null) {
+                    // ask for the message
+                    AskMessageOutput(contact.name, numbers[0])
+                } else {
+                    // we have everything, confirm sending
+                    ConfirmSmsOutput(contact.name, numbers[0], messageText)
+                }
+            }
+            validContacts.add(Pair(contact.name, numbers))
+            ++i
+        }
+
+        if (validContacts.size == 1 // there is exactly one valid contact and ...
+            // ... either it has exactly one number, or we would be forced (because no number parser
+            // is available) to use ContactChooserName, which only uses the first phone number
+            // anyway
+            && (validContacts[0].second.size == 1 || ctx.parserFormatter == null)
+        ) {
+            // not a good enough match, but since we have only this, use it
+            val contact = validContacts[0]
+            return if (messageText == null) {
+                AskMessageOutput(contact.first, contact.second[0])
+            } else {
+                ConfirmSmsOutput(contact.first, contact.second[0], messageText)
+            }
+        }
+
+        // this point will not be reached if a very close match was found
+        return SmsOutput(validContacts, messageText)
+    }
+
+    companion object {
+        fun sendSms(number: String, message: String) {
+            val smsManager = SmsManager.getDefault()
+            smsManager.sendTextMessage(number, null, message, null, null)
+        }
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/util/PermissionUtils.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/util/PermissionUtils.kt
@@ -27,6 +27,10 @@ val PERMISSION_CALL_PHONE = Permission.NormalPermission(
     name = R.string.perm_call_phone,
     id = Manifest.permission.CALL_PHONE,
 )
+val PERMISSION_SEND_SMS = Permission.NormalPermission(
+    name = R.string.perm_send_sms,
+    id = Manifest.permission.SEND_SMS,
+)
 
 /**
  * @param context the Android context

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="pref_stt_play_sound_none">Do not play sound</string>
     <string name="perm_read_contacts">read your contacts</string>
     <string name="perm_call_phone">directly call phone numbers</string>
+    <string name="perm_send_sms">send SMS messages</string>
     <string name="settings_description_with_value">%1$s — %2$s</string>
     <string name="eval_missing_permissions">The skill \"%1$s\" needs these permissions to work: %2$s</string>
     <string name="eval_fatal_error">Could not evaluate your request</string>
@@ -148,6 +149,8 @@
     <string name="skill_navigation_navigating_to">Navigating to %1$s</string>
     <string name="skill_name_telephone">Telephone</string>
     <string name="skill_sentence_example_telephone">Call Tom</string>
+    <string name="skill_name_sms">SMS</string>
+    <string name="skill_sentence_example_sms">Send a message to Tom</string>
     <string name="skill_name_timer">Timer</string>
     <string name="skill_sentence_example_timer">Set a timer for five minutes</string>
     <string name="skill_name_current_time">Current time</string>
@@ -177,6 +180,12 @@
     <string name="skill_telephone_confirm_call">Should I call %1$s?</string>
     <string name="skill_telephone_calling">Calling %1$s…</string>
     <string name="skill_telephone_not_calling">OK, I am not calling anyone</string>
+    <string name="skill_sms_unknown_contact">No contact found, try again</string>
+    <string name="skill_sms_found_contacts">I found %1$d contacts, which one shall I message?</string>
+    <string name="skill_sms_what_message">What do you want the message to say?</string>
+    <string name="skill_sms_confirm">Should I send \"%1$s\" to %2$s?</string>
+    <string name="skill_sms_sent">Message sent to %1$s</string>
+    <string name="skill_sms_not_sending">OK, I am not sending any message</string>
     <string name="skill_time_current_time">Right now, it is %1$s</string>
     <string name="skill_timer_how_much_time">How much time should the timer last?</string>
     <string name="skill_timer_confirm_cancel">Are you sure you want to cancel all timers?</string>

--- a/app/src/main/sentences/en/sms.yml
+++ b/app/src/main/sentences/en/sms.yml
@@ -1,0 +1,7 @@
+send:
+  - send a?n? (message|text|sms) to .who. saying .what.
+  - send a?n? (message|text|sms) to .who. that says .what.
+  - (message|text|sms) .who. saying .what.
+  - (message|text|sms) .who. that says .what.
+  - send a?n? (message|text|sms) to .who.
+  - (message|text|sms) .who.

--- a/app/src/main/sentences/skill_definitions.yml
+++ b/app/src/main/sentences/skill_definitions.yml
@@ -123,3 +123,13 @@ skills:
             type: string
           - id: target
             type: string
+
+  - id: sms
+    specificity: low
+    sentences:
+      - id: send
+        captures:
+          - id: who
+            type: string
+          - id: what
+            type: string

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -8,6 +8,7 @@ Dicio answers questions about:
 <li><b>open</b>: opens an app on your device - <i>Open NewPipe</i></li>
 <li><b>calculator</b>: evaluates basic calculations - <i>What is four thousand and two times three minus a million divided by three hundred?</i></li>
 <li><b>telephone</b>: view and call contacts - <i>Call Tom</i></li>
+<li><b>sms</b>: send SMS messages to contacts - <i>Send a text to Jenna saying I got us reservations for dinner</i></li>
 <li><b>timer</b>: set, query and cancel timers - <i>Set a timer for eleven minutes</i></li>
 <li><b>current time</b>: query current time - <i>What time is it?</i></li>
 <li><b>navigation</b>: opens the navigation app at the requested position - <i>Take me to New York, fifteenth avenue</i></li>


### PR DESCRIPTION
Added SMS skill, based on the telephone skill. 

The sentences are setup so you can add your message into the first query ("Send a message to Tyler that says Can you grab cat food at the store") or in two-steps ("Send a message to Tyler" -> "What do you want the message to say?" -> "Can you grab cat food at the store?")

Resolves https://github.com/Stypox/dicio-android/issues/270