### PR TITLE
Add Cancel/Dismiss pseudo-skill

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/eval/SkillHandler.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/eval/SkillHandler.kt
@@ -18,6 +18,7 @@ import org.stypox.dicio.di.SkillContextInternal
 import org.stypox.dicio.settings.datastore.UserSettings
 import org.stypox.dicio.settings.datastore.UserSettingsModule
 import org.stypox.dicio.skills.calculator.CalculatorInfo
+import org.stypox.dicio.skills.cancel.CancelInfo
 import org.stypox.dicio.skills.current_time.CurrentTimeInfo
 import org.stypox.dicio.skills.fallback.text.TextFallbackInfo
 import org.stypox.dicio.skills.listening.ListeningInfo
@@ -57,6 +58,11 @@ class SkillHandler @Inject constructor(
         TranslationInfo,
     )
 
+    // Hidden skills that are always enabled but don't appear in menus
+    private val hiddenSkillInfoList = listOf(
+        CancelInfo,
+    )
+
     private val fallbackSkillInfoList = listOf(
         TextFallbackInfo,
     )
@@ -87,7 +93,10 @@ class SkillHandler @Inject constructor(
 
                     _enabledSkillsInfo.value = newEnabledSkillsInfo
                     _skillRanker.value = SkillRanker(
-                        newEnabledSkillsInfo.map(::buildSkillFromInfo),
+                        newEnabledSkillsInfo.map(::buildSkillFromInfo)
+                            + hiddenSkillInfoList
+                                .filter { it.isAvailable(skillContext) }
+                                .map(::buildSkillFromInfo),
                         buildSkillFromInfo(fallbackSkillInfoList[0]),
                     )
                 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/cancel/CancelInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/cancel/CancelInfo.kt
@@ -1,0 +1,32 @@
+package org.stypox.dicio.skills.cancel
+
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.Skill
+import org.dicio.skill.skill.SkillInfo
+import org.stypox.dicio.R
+import org.stypox.dicio.sentences.Sentences
+
+object CancelInfo : SkillInfo("cancel") {
+    override fun name(context: Context) =
+        context.getString(R.string.skill_name_cancel)
+
+    override fun sentenceExample(context: Context) =
+        context.getString(R.string.skill_sentence_example_cancel)
+
+    @Composable
+    override fun icon() =
+        rememberVectorPainter(Icons.Default.Cancel)
+
+    override fun isAvailable(ctx: SkillContext): Boolean {
+        return Sentences.Cancel[ctx.sentencesLanguage] != null
+    }
+
+    override fun build(ctx: SkillContext): Skill<*> {
+        return CancelSkill(CancelInfo, Sentences.Cancel[ctx.sentencesLanguage]!!)
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/cancel/CancelOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/cancel/CancelOutput.kt
@@ -1,0 +1,15 @@
+package org.stypox.dicio.skills.cancel
+
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.InteractionPlan
+import org.stypox.dicio.R
+import org.stypox.dicio.io.graphical.HeadlineSpeechSkillOutput
+import org.stypox.dicio.util.getString
+
+class CancelOutput : HeadlineSpeechSkillOutput {
+    override fun getSpeechOutput(ctx: SkillContext): String =
+        ctx.getString(R.string.skill_cancel_confirmation)
+
+    override fun getInteractionPlan(ctx: SkillContext): InteractionPlan =
+        InteractionPlan.FinishInteraction
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/cancel/CancelSkill.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/cancel/CancelSkill.kt
@@ -1,0 +1,18 @@
+package org.stypox.dicio.skills.cancel
+
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.SkillInfo
+import org.dicio.skill.skill.SkillOutput
+import org.dicio.skill.standard.StandardRecognizerData
+import org.dicio.skill.standard.StandardRecognizerSkill
+import org.stypox.dicio.sentences.Sentences.Cancel
+
+class CancelSkill(
+    correspondingSkillInfo: SkillInfo,
+    data: StandardRecognizerData<Cancel>
+) : StandardRecognizerSkill<Cancel>(correspondingSkillInfo, data) {
+
+    override suspend fun generateOutput(ctx: SkillContext, inputData: Cancel): SkillOutput {
+        return CancelOutput()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,7 +223,7 @@
     <string name="skill_sentence_example_listening">Stop listening</string>
     <string name="skill_cancel_confirmation">Okay</string>
     <string name="skill_name_cancel">Cancel</string>
-    <string name="skill_sentence_example_cancel">Cancel</string>
+    <string name="skill_sentence_example_cancel">Nevermind</string>
     <string name="skill_translation_success">Translated to %1$s</string>
     <string name="skill_translation_unknown_language">I don\'t recognize language %1$s</string>
     <string name="skill_translation_unsupported_language">Language %1$s (%2$s) is not supported</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,7 +222,7 @@
     <string name="skill_name_listening">Control wake word listening</string>
     <string name="skill_sentence_example_listening">Stop listening</string>
     <string name="skill_cancel_confirmation">Okay</string>
-    <string name="skill_name_cancel">Cancel</string>
+    <string name="skill_name_cancel">Cancel interaction</string>
     <string name="skill_sentence_example_cancel">Nevermind</string>
     <string name="skill_translation_success">Translated to %1$s</string>
     <string name="skill_translation_unknown_language">I don\'t recognize language %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,6 +221,9 @@
     <string name="skill_listening_disabled">The wake word service is disabled in settings</string>
     <string name="skill_name_listening">Control wake word listening</string>
     <string name="skill_sentence_example_listening">Stop listening</string>
+    <string name="skill_cancel_confirmation">Okay</string>
+    <string name="skill_name_cancel">Cancel</string>
+    <string name="skill_sentence_example_cancel">Cancel</string>
     <string name="skill_translation_success">Translated to %1$s</string>
     <string name="skill_translation_unknown_language">I don\'t recognize language %1$s</string>
     <string name="skill_translation_unsupported_language">Language %1$s (%2$s) is not supported</string>

--- a/app/src/main/sentences/en/cancel.yml
+++ b/app/src/main/sentences/en/cancel.yml
@@ -1,2 +1,2 @@
 exit:
-  - cancel|exit|stop|quit|dismiss|(never mind)|nevermind|(forget it)|(no thanks)
+  - cancel|exit|stop|quit|dismiss|(never mind)|nevermind|(forget it)|(no thanks?)

--- a/app/src/main/sentences/en/cancel.yml
+++ b/app/src/main/sentences/en/cancel.yml
@@ -1,0 +1,2 @@
+exit:
+  - cancel|exit|stop|quit|dismiss|(never mind)|nevermind|(forget it)|(no thanks)

--- a/app/src/main/sentences/skill_definitions.yml
+++ b/app/src/main/sentences/skill_definitions.yml
@@ -64,6 +64,11 @@ skills:
       - id: stop
       - id: start
 
+  - id: cancel
+    specificity: high
+    sentences:
+      - id: exit
+
   - id: search
     specificity: low
     sentences:


### PR DESCRIPTION
Adds a cancel/dismiss pseudo-skill so users can dismiss the assistant after intentional or unintentional activation.

Also sets up a hidden skills section so it doesn't show up in Settings or on the What I Can Do card.

Resolves https://github.com/Stypox/dicio-android/issues/334