### PR TITLE
Add volume controls to media skill

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/skills/media/MediaOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/media/MediaOutput.kt
@@ -15,5 +15,9 @@ class MediaOutput(
         is Media.Pause -> ctx.getString(R.string.skill_media_pausing)
         is Media.Previous -> ctx.getString(R.string.skill_media_previous)
         is Media.Next -> ctx.getString(R.string.skill_media_next)
+        is Media.VolumeUp -> ctx.getString(R.string.skill_media_volume_up)
+        is Media.VolumeDown -> ctx.getString(R.string.skill_media_volume_down)
+        is Media.VolumeUpTimes -> ctx.getString(R.string.skill_media_volume_up)
+        is Media.VolumeDownTimes -> ctx.getString(R.string.skill_media_volume_down)
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/media/MediaSkill.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/media/MediaSkill.kt
@@ -17,16 +17,77 @@ class MediaSkill(correspondingSkillInfo: SkillInfo, data: StandardRecognizerData
         val audioManager = getSystemService(ctx.android, AudioManager::class.java)
             ?: return MediaOutput(performedAction = null) // no media session found
 
-        val key = when (inputData) {
-            is Media.Play -> KeyEvent.KEYCODE_MEDIA_PLAY
-            is Media.Pause -> KeyEvent.KEYCODE_MEDIA_PAUSE
-            is Media.Previous -> KeyEvent.KEYCODE_MEDIA_PREVIOUS
-            is Media.Next -> KeyEvent.KEYCODE_MEDIA_NEXT
+        when (inputData) {
+            is Media.Play -> {
+                audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PLAY))
+                audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PLAY))
+            }
+            is Media.Pause -> {
+                audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PAUSE))
+                audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PAUSE))
+            }
+            is Media.Previous -> {
+                audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_PREVIOUS))
+                audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PREVIOUS))
+            }
+            is Media.Next -> {
+                audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_MEDIA_NEXT))
+                audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_NEXT))
+            }
+            is Media.VolumeUp -> {
+                audioManager.adjustStreamVolume(
+                    AudioManager.STREAM_MUSIC,
+                    AudioManager.ADJUST_RAISE,
+                    AudioManager.FLAG_SHOW_UI
+                )
+            }
+            is Media.VolumeDown -> {
+                audioManager.adjustStreamVolume(
+                    AudioManager.STREAM_MUSIC,
+                    AudioManager.ADJUST_LOWER,
+                    AudioManager.FLAG_SHOW_UI
+                )
+            }
+            is Media.VolumeUpTimes -> {
+                val times = extractNumberFromString(ctx, inputData.times)
+                repeat(times) {
+                    audioManager.adjustStreamVolume(
+                        AudioManager.STREAM_MUSIC,
+                        AudioManager.ADJUST_RAISE,
+                        if (it == 0) AudioManager.FLAG_SHOW_UI else 0
+                    )
+                }
+            }
+            is Media.VolumeDownTimes -> {
+                val times = extractNumberFromString(ctx, inputData.times)
+                repeat(times) {
+                    audioManager.adjustStreamVolume(
+                        AudioManager.STREAM_MUSIC,
+                        AudioManager.ADJUST_LOWER,
+                        if (it == 0) AudioManager.FLAG_SHOW_UI else 0
+                    )
+                }
+            }
         }
 
-        audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, key))
-        audioManager.dispatchMediaKeyEvent(KeyEvent(KeyEvent.ACTION_UP, key))
         return MediaOutput(performedAction = inputData)
+    }
+
+    private fun extractNumberFromString(ctx: SkillContext, input: String?): Int {
+        if (input.isNullOrBlank()) {
+            return 1
+        }
+
+        return ctx.parserFormatter!!
+            .extractNumber(input)
+            .mixedWithText
+            .asSequence()
+            .filterIsInstance<org.dicio.numbers.unit.Number>()
+            .filter { it.isInteger }
+            .map { it.integerValue().toInt() }
+            .firstOrNull()
+            ?.coerceIn(1, 10) // Limit to 1-10 steps for safety
+            ?: 1
     }
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,8 @@
     <string name="skill_media_pausing">Pausing media…</string>
     <string name="skill_media_previous">Previous media…</string>
     <string name="skill_media_next">Next media…</string>
+    <string name="skill_media_volume_up">Increasing volume</string>
+    <string name="skill_media_volume_down">Decreasing volume</string>
     <string name="skill_media_no_media_session">No media session is active</string>
     <string name="skill_calculator_could_not_calculate">I could not calculate your request</string>
     <string name="skill_telephone_unknown_contact">No contact found, try again</string>

--- a/app/src/main/sentences/de/media.yml
+++ b/app/src/main/sentences/de/media.yml
@@ -17,22 +17,9 @@ next:
   - spiel<e?>|spring<e?>|geh<e?>? das|den|die|zu<m|r>? nächste<s|n?>|folgende<s|n?> audio|film|hör<buch|spiel>|lied|musik<stück?>|podcast|song|stream|stück|track|video? (in der <warte?>schlange)?
 
 volume_up:
-  - erhöh<e?>|erhöhen|hoch drehen (die? lautstärke|sound|ton|volumen)
-  - lautstärke hoch|rauf
-  - lauter
-  - mach<e?> es lauter
 
 volume_down:
-  - verringer<e?>|verringern|runter drehen (die? lautstärke|sound|ton|volumen)
-  - lautstärke runter
-  - leiser
-  - mach<e?> es leiser
 
 volume_up_times:
-  - erhöh<e?>|erhöhen (die? lautstärke|sound|ton|volumen|es)? .times. mal|schritte?
-  - mach<e?> es .times. mal|schritte? lauter
 
 volume_down_times:
-  - verringer<e?>|verringern (die? lautstärke|sound|ton|volumen|es)? .times. mal|schritte?
-  - mach<e?> es .times. mal|schritte? leiser
-  

--- a/app/src/main/sentences/de/media.yml
+++ b/app/src/main/sentences/de/media.yml
@@ -35,3 +35,4 @@ volume_up_times:
 volume_down_times:
   - verringer<e?>|verringern (die? lautstärke|sound|ton|volumen|es)? .times. mal|schritte?
   - mach<e?> es .times. mal|schritte? leiser
+  

--- a/app/src/main/sentences/de/media.yml
+++ b/app/src/main/sentences/de/media.yml
@@ -15,3 +15,23 @@ previous:
 next:
   - skip<e?>|überspring<e?>|ueberspring<e?> das|den|die|ein<e|en?>? audio|film|hör<buch|spiel>|lied|musik<stück?>|podcast|song|stream|stück|track|video
   - spiel<e?>|spring<e?>|geh<e?>? das|den|die|zu<m|r>? nächste<s|n?>|folgende<s|n?> audio|film|hör<buch|spiel>|lied|musik<stück?>|podcast|song|stream|stück|track|video? (in der <warte?>schlange)?
+
+volume_up:
+  - erhöh<e?>|erhöhen|hoch drehen (die? lautstärke|sound|ton|volumen)
+  - lautstärke hoch|rauf
+  - lauter
+  - mach<e?> es lauter
+
+volume_down:
+  - verringer<e?>|verringern|runter drehen (die? lautstärke|sound|ton|volumen)
+  - lautstärke runter
+  - leiser
+  - mach<e?> es leiser
+
+volume_up_times:
+  - erhöh<e?>|erhöhen (die? lautstärke|sound|ton|volumen|es)? .times. mal|schritte?
+  - mach<e?> es .times. mal|schritte? lauter
+
+volume_down_times:
+  - verringer<e?>|verringern (die? lautstärke|sound|ton|volumen|es)? .times. mal|schritte?
+  - mach<e?> es .times. mal|schritte? leiser

--- a/app/src/main/sentences/en/media.yml
+++ b/app/src/main/sentences/en/media.yml
@@ -14,3 +14,23 @@ previous:
 next:
   - skip the|a|one? song|media|track|music|audio|video|movie|stream|film
   - play|(go|switch|skip|jump|(move forward) to)? the? next|following song|media|track|music|audio|video|movie|stream|film? (in the queue)?
+
+volume_up:
+  - (increase|raise|turn) up? the? (volume|sound) up?
+  - volume up
+  - (make it)? louder
+
+volume_down:
+  - (decrease|lower|turn) down? the? (volume|sound) down?
+  - volume down
+  - (make it)? quieter
+
+volume_up_times:
+  - (increase|raise|turn) (it|the? volume|sound)? up .times. (times|clicks|steps|notches)?
+  - .times. times|clicks|steps|notches? louder
+  - make it .times. times|clicks|steps|notches? louder
+
+volume_down_times:
+  - (decrease|lower|turn) (it|the? volume|sound)? down .times. (times|clicks|steps|notches)?
+  - .times. times|clicks|steps|notches? quieter
+  - make it .times. times|clicks|steps|notches? quieter

--- a/app/src/main/sentences/en/media.yml
+++ b/app/src/main/sentences/en/media.yml
@@ -16,21 +16,23 @@ next:
   - play|(go|switch|skip|jump|(move forward) to)? the? next|following song|media|track|music|audio|video|movie|stream|film? (in the queue)?
 
 volume_up:
-  - (increase|raise|turn) up? the? (volume|sound) up?
-  - volume up
-  - (make it)? louder
+  - increase|raise|(turn up) the? volume|sound
+  - (turn the?)? volume|sound up
+  - (make the?)? volume|sound|song|media|track|music|audio|video|movie|stream|film louder
 
 volume_down:
-  - (decrease|lower|turn) down? the? (volume|sound) down?
-  - volume down
-  - (make it)? quieter
+  - decrease|lower|(turn down) the? volume|sound
+  - (turn the?)? volume|sound down
+  - (make the?)? volume|sound|song|media|track|music|audio|video|movie|stream|film quieter
 
 volume_up_times:
-  - (increase|raise|turn) up? the? (it|volume|sound)? up? .times. (times|clicks|steps|notches)?
-  - .times. times|clicks|steps|notches? louder
-  - make it .times. times|clicks|steps|notches? louder
+  - increase|raise|(turn up) the? volume|sound by? .times. times|clicks|steps|notches|levels?
+  - (turn the?)? volume|sound up by? .times. times|clicks|steps|notches|levels?
+  - (make the?)? volume|sound|song|media|track|music|audio|video|movie|stream|film louder by .times. times|clicks|steps|notches|levels?
+  - (make the?)? volume|sound|song|media|track|music|audio|video|movie|stream|film .times. times|clicks|steps|notches|levels louder
 
 volume_down_times:
-  - (decrease|lower|turn) down? the? (it|volume|sound)? down? .times. (times|clicks|steps|notches)?
-  - .times. times|clicks|steps|notches? quieter
-  - make it .times. times|clicks|steps|notches? quieter
+  - decrease|lower|(turn down) the? volume|sound by? .times. times|clicks|steps|notches|levels?
+  - (turn the?)? volume|sound down by? .times. times|clicks|steps|notches|levels?
+  - (make the?)? volume|sound|song|media|track|music|audio|video|movie|stream|film quieter by .times. times|clicks|steps|notches|levels?
+  - (make the?)? volume|sound|song|media|track|music|audio|video|movie|stream|film .times. times|clicks|steps|notches|levels quieter

--- a/app/src/main/sentences/en/media.yml
+++ b/app/src/main/sentences/en/media.yml
@@ -26,11 +26,11 @@ volume_down:
   - (make it)? quieter
 
 volume_up_times:
-  - (increase|raise|turn) (it|the? volume|sound)? up .times. (times|clicks|steps|notches)?
+  - (increase|raise|turn) up? the? (it|volume|sound)? up? .times. (times|clicks|steps|notches)?
   - .times. times|clicks|steps|notches? louder
   - make it .times. times|clicks|steps|notches? louder
 
 volume_down_times:
-  - (decrease|lower|turn) (it|the? volume|sound)? down .times. (times|clicks|steps|notches)?
+  - (decrease|lower|turn) down? the? (it|volume|sound)? down? .times. (times|clicks|steps|notches)?
   - .times. times|clicks|steps|notches? quieter
   - make it .times. times|clicks|steps|notches? quieter

--- a/app/src/main/sentences/es/media.yml
+++ b/app/src/main/sentences/es/media.yml
@@ -37,3 +37,4 @@ volume_up_times:
 volume_down_times:
   - bajar|disminuir (el? volumen|sonido)? .times. veces|pasos?
   - .times. veces|pasos? mas bajo|suave
+  

--- a/app/src/main/sentences/es/media.yml
+++ b/app/src/main/sentences/es/media.yml
@@ -17,3 +17,23 @@ next:
   - reproducir|sonar|saltar el|la? cancion|<multi?>media|pista|musica|audio|video|film|peli<cula?>|stream|transmision siguiente|posterior<a?>|sucesor<a?> (de|en la cola|fila)?
   - reproducir|sonar|saltar el|la? siguiente|posterior<a?>|sucesor<a?> cancion|<multi?>media|pista|musica|audio|video|film|peli<cula?>|stream|transmision (de|en la cola|fila)?
   - ir|saltar|omitir (a el)|al|la siguiente|sucesor<a?>
+
+volume_up:
+  - subir|aumentar (el? volumen|sonido)
+  - volumen arriba
+  - mas alto
+  - mas fuerte
+
+volume_down:
+  - bajar|disminuir (el? volumen|sonido)
+  - volumen abajo
+  - mas bajo
+  - mas suave
+
+volume_up_times:
+  - subir|aumentar (el? volumen|sonido)? .times. veces|pasos?
+  - .times. veces|pasos? mas alto|fuerte
+
+volume_down_times:
+  - bajar|disminuir (el? volumen|sonido)? .times. veces|pasos?
+  - .times. veces|pasos? mas bajo|suave

--- a/app/src/main/sentences/es/media.yml
+++ b/app/src/main/sentences/es/media.yml
@@ -19,22 +19,9 @@ next:
   - ir|saltar|omitir (a el)|al|la siguiente|sucesor<a?>
 
 volume_up:
-  - subir|aumentar (el? volumen|sonido)
-  - volumen arriba
-  - mas alto
-  - mas fuerte
 
 volume_down:
-  - bajar|disminuir (el? volumen|sonido)
-  - volumen abajo
-  - mas bajo
-  - mas suave
 
 volume_up_times:
-  - subir|aumentar (el? volumen|sonido)? .times. veces|pasos?
-  - .times. veces|pasos? mas alto|fuerte
 
 volume_down_times:
-  - bajar|disminuir (el? volumen|sonido)? .times. veces|pasos?
-  - .times. veces|pasos? mas bajo|suave
-  

--- a/app/src/main/sentences/fr/media.yml
+++ b/app/src/main/sentences/fr/media.yml
@@ -12,3 +12,23 @@ previous:
 
 next:
   - (joue|jouer|jouez|mais|mets|mettez|mettre|(passe à)|(passer à)|(passez à))? la|le? chanson|média|piste|musique|audio|film|stream suivant<e?>
+
+volume_up:
+  - augmente|augmenter|augmentez|monte|monter|montez (le? volume|son)
+  - volume plus haut
+  - plus fort
+  - plus haut
+
+volume_down:
+  - baisse|baisser|baissez|diminue|diminuer|diminuez (le? volume|son)
+  - volume plus bas
+  - plus bas
+  - moins fort
+
+volume_up_times:
+  - augmente|augmenter|augmentez|monte|monter|montez (le? volume|son)? (de)? .times. fois|crans?
+  - .times. fois|crans? plus fort|haut
+
+volume_down_times:
+  - baisse|baisser|baissez|diminue|diminuer|diminuez (le? volume|son)? (de)? .times. fois|crans?
+  - .times. fois|crans? plus bas|moins fort

--- a/app/src/main/sentences/fr/media.yml
+++ b/app/src/main/sentences/fr/media.yml
@@ -14,21 +14,9 @@ next:
   - (joue|jouer|jouez|mais|mets|mettez|mettre|(passe à)|(passer à)|(passez à))? la|le? chanson|média|piste|musique|audio|film|stream suivant<e?>
 
 volume_up:
-  - augmente|augmenter|augmentez|monte|monter|montez (le? volume|son)
-  - volume plus haut
-  - plus fort
-  - plus haut
 
 volume_down:
-  - baisse|baisser|baissez|diminue|diminuer|diminuez (le? volume|son)
-  - volume plus bas
-  - plus bas
-  - moins fort
 
 volume_up_times:
-  - augmente|augmenter|augmentez|monte|monter|montez (le? volume|son)? (de)? .times. fois|crans?
-  - .times. fois|crans? plus fort|haut
 
 volume_down_times:
-  - baisse|baisser|baissez|diminue|diminuer|diminuez (le? volume|son)? (de)? .times. fois|crans?
-  - .times. fois|crans? plus bas|moins fort

--- a/app/src/main/sentences/it/media.yml
+++ b/app/src/main/sentences/it/media.yml
@@ -18,21 +18,17 @@ next:
   - (metti il|la)|(passa|vai al<la?>)? successiv<a|o>|prossim<a|o> canzone|traccia|musica|audio|brano|video
 
 volume_up:
-  - alza|aumenta (il? volume|suono|audio)
-  - volume su
-  - più alto
-  - più forte
+  - alza|aumenta|incrementa il|l<o|a?>? volume|suono|audio
+  - volume su|(più alto|forte)
 
 volume_down:
-  - abbassa|diminuisci (il? volume|suono|audio)
-  - volume giù
-  - più basso
-  - più silenzioso
+  - abbassa|diminuisci|riduci il|l<o|a?>? volume|suono|audio
+  - volume giù|(più basso|silenzioso)
 
 volume_up_times:
-  - alza|aumenta (il? volume|suono|audio)? (di)? .times. volte|passi?
-  - .times. volte|passi? più alto|forte
+  - alza|aumenta|incrementa il|l<o|a?>? volume|suono|audio di? .times. volte|passi|tacche|livelli?
+  - volume su|(più alto|forte) di? .times. volte|passi|tacche|livelli?
 
 volume_down_times:
-  - abbassa|diminuisci (il? volume|suono|audio)? (di)? .times. volte|passi?
-  - .times. volte|passi? più basso|silenzioso
+  - abbassa|diminuisci|riduci il|l<o|a?>? volume|suono|audio di? .times. volte|passi|tacche|livelli?
+  - volume giù|(più basso|silenzioso) di? .times. volte|passi|tacche|livelli?

--- a/app/src/main/sentences/it/media.yml
+++ b/app/src/main/sentences/it/media.yml
@@ -16,3 +16,23 @@ next:
   - vai|butta? in? avanti di una canzone|traccia|musica|audio|brano|video
   - (metti il|la)|(passa|vai al<la?>)? canzone|traccia|musica|audio|brano|video successiv<a|o>|dopo
   - (metti il|la)|(passa|vai al<la?>)? successiv<a|o>|prossim<a|o> canzone|traccia|musica|audio|brano|video
+
+volume_up:
+  - alza|aumenta (il? volume|suono|audio)
+  - volume su
+  - più alto
+  - più forte
+
+volume_down:
+  - abbassa|diminuisci (il? volume|suono|audio)
+  - volume giù
+  - più basso
+  - più silenzioso
+
+volume_up_times:
+  - alza|aumenta (il? volume|suono|audio)? (di)? .times. volte|passi?
+  - .times. volte|passi? più alto|forte
+
+volume_down_times:
+  - abbassa|diminuisci (il? volume|suono|audio)? (di)? .times. volte|passi?
+  - .times. volte|passi? più basso|silenzioso

--- a/app/src/main/sentences/nl/media.yml
+++ b/app/src/main/sentences/nl/media.yml
@@ -15,3 +15,23 @@ next:
   - skip (dit|deze)? (lied<je?>|nummer|song|muziek<je?>|audio|video|film<pje?>|stream|clip)?
   - speel|start|begin|(skip naar)|(ga (verder met)|naar) (de|het)? volgende lied<je?>|nummer|song|muziek<je?>|audio|video|film<pje?>|stream|clip afspelen?
   - volgende (lied<je?>|nummer|song|muziek<je?>|audio|video|film<pje?>|stream|clip)?
+
+volume_up:
+  - verhoog|verhogen|harder zetten (de|het? volume|geluid)
+  - volume omhoog
+  - harder
+  - luider
+
+volume_down:
+  - verlaag|verlagen|zachter zetten (de|het? volume|geluid)
+  - volume omlaag
+  - zachter
+  - stiller
+
+volume_up_times:
+  - verhoog|verhogen (de|het? volume|geluid|het)? .times. keer|stappen?
+  - .times. keer|stappen? harder|luider
+
+volume_down_times:
+  - verlaag|verlagen (de|het? volume|geluid|het)? .times. keer|stappen?
+  - .times. keer|stappen? zachter|stiller

--- a/app/src/main/sentences/nl/media.yml
+++ b/app/src/main/sentences/nl/media.yml
@@ -17,21 +17,9 @@ next:
   - volgende (lied<je?>|nummer|song|muziek<je?>|audio|video|film<pje?>|stream|clip)?
 
 volume_up:
-  - verhoog|verhogen|harder zetten (de|het? volume|geluid)
-  - volume omhoog
-  - harder
-  - luider
 
 volume_down:
-  - verlaag|verlagen|zachter zetten (de|het? volume|geluid)
-  - volume omlaag
-  - zachter
-  - stiller
 
 volume_up_times:
-  - verhoog|verhogen (de|het? volume|geluid|het)? .times. keer|stappen?
-  - .times. keer|stappen? harder|luider
 
 volume_down_times:
-  - verlaag|verlagen (de|het? volume|geluid|het)? .times. keer|stappen?
-  - .times. keer|stappen? zachter|stiller

--- a/app/src/main/sentences/skill_definitions.yml
+++ b/app/src/main/sentences/skill_definitions.yml
@@ -44,6 +44,16 @@ skills:
       - id: pause
       - id: previous
       - id: next
+      - id: volume_up
+      - id: volume_down
+      - id: volume_up_times
+        captures:
+          - id: times
+            type: string
+      - id: volume_down_times
+        captures:
+          - id: times
+            type: string
 
   - id: joke
     specificity: high

--- a/app/src/main/sentences/sv/media.yml
+++ b/app/src/main/sentences/sv/media.yml
@@ -32,3 +32,4 @@ volume_up_times:
 volume_down_times:
   - sänk|minska volym<en?>|ljud<et?>|det? .times. gånger|steg?
   - .times. gånger|steg? lägre
+  

--- a/app/src/main/sentences/sv/media.yml
+++ b/app/src/main/sentences/sv/media.yml
@@ -12,3 +12,23 @@ previous:
 next:
   - skippa|(hoppa över?) en|nästa? sång<en?>|media|låt<en?>|musik<en?>|audio|video<n?>|film<en?>|stream<en?>
   - spela|(byt|hoppa|växla till) nästa|följande sång<en?>|media|låt<en?>|musik<en?>|audio|video<n?>|film<en?>|stream<en?> (i kön)?
+
+volume_up:
+  - höj|öka volym<en?>|ljud<et?>
+  - volym upp
+  - högre
+  - gör det högre
+
+volume_down:
+  - sänk|minska volym<en?>|ljud<et?>
+  - volym ner
+  - lägre
+  - gör det lägre
+
+volume_up_times:
+  - höj|öka volym<en?>|ljud<et?>|det? .times. gånger|steg?
+  - .times. gånger|steg? högre
+
+volume_down_times:
+  - sänk|minska volym<en?>|ljud<et?>|det? .times. gånger|steg?
+  - .times. gånger|steg? lägre

--- a/app/src/main/sentences/sv/media.yml
+++ b/app/src/main/sentences/sv/media.yml
@@ -14,22 +14,9 @@ next:
   - spela|(byt|hoppa|växla till) nästa|följande sång<en?>|media|låt<en?>|musik<en?>|audio|video<n?>|film<en?>|stream<en?> (i kön)?
 
 volume_up:
-  - höj|öka volym<en?>|ljud<et?>
-  - volym upp
-  - högre
-  - gör det högre
 
 volume_down:
-  - sänk|minska volym<en?>|ljud<et?>
-  - volym ner
-  - lägre
-  - gör det lägre
 
 volume_up_times:
-  - höj|öka volym<en?>|ljud<et?>|det? .times. gånger|steg?
-  - .times. gånger|steg? högre
 
 volume_down_times:
-  - sänk|minska volym<en?>|ljud<et?>|det? .times. gånger|steg?
-  - .times. gånger|steg? lägre
-  

--- a/app/src/main/sentences/tr/media.yml
+++ b/app/src/main/sentences/tr/media.yml
@@ -12,3 +12,11 @@ previous:
 next:
   - (bir? sonraki)|(bir? ilerideki|sıradaki) (şarkı<yı|ya?>|medya<yı|ya?>|parça<yı|ya?>|müzi<k|ği|ğe?>|ses<i|e?>|video<yu|ya?>|dizi<yi|ye?>|yayın<ı|a?>|film<i|e?>) geç|oynat|git|değiş<tir?>|geç|zıpla|(ileri sar<dır|dırt?>)
   - ileri sar
+
+volume_up:
+
+volume_down:
+
+volume_up_times:
+
+volume_down_times:

--- a/sentences-compiler-plugin/src/main/kotlin/org/stypox/dicio/sentencesCompilerPlugin/data/ExtractDataFromFiles.kt
+++ b/sentences-compiler-plugin/src/main/kotlin/org/stypox/dicio/sentencesCompilerPlugin/data/ExtractDataFromFiles.kt
@@ -21,7 +21,7 @@ fun extractDataFromFiles(logger: Logger, inputDirFile: File): ExtractedData {
                 continue
             }
 
-            val parsedSentences: Map<String, List<String>?> = parseYamlFile(file)
+            val parsedSentences: Map<String, Any?> = parseYamlFile(file)
             val expectedSentenceIds = skill.sentences.map { it.id }.toSet()
             if (!parsedSentences.keys.containsAll(expectedSentenceIds)) {
                 throw SentencesCompilerPluginException(
@@ -41,22 +41,21 @@ fun extractDataFromFiles(logger: Logger, inputDirFile: File): ExtractedData {
                 )
             }
 
-            val emptySentences = parsedSentences
-                .filter { it.value.isNullOrEmpty() }
-                .map { it.key }
-            if (emptySentences.isNotEmpty()) {
-                logger.error(
-                    "[Warning] Skill sentences file ${lang.name}/${
-                        file.name
-                    } has no sentence definitions for these sentence ids ${
-                        emptySentences
-                    }: ${file.absolutePath}"
-                )
-            }
-
+            val emptySentenceIds = ArrayList<String>()
             for ((sentenceId, parsedSentencesWithoutId) in parsedSentences) {
-                if (parsedSentencesWithoutId == null) {
-                    continue // the warning was issued above
+                if ((parsedSentencesWithoutId as? String)?.isBlank() == true
+                    || (parsedSentencesWithoutId as? List<*>)?.isEmpty() == true
+                ) {
+                    emptySentenceIds.add(sentenceId)
+                    continue // a warning is raised below
+                } else if ((parsedSentencesWithoutId as? List<*>)?.all { it is String } != true) {
+                    throw SentencesCompilerPluginException(
+                        "Skill sentences file ${lang.name}/${
+                            file.name
+                        } contains an invalid value for sentence id ${
+                            sentenceId
+                        }: ${file.absolutePath}"
+                    )
                 }
 
                 // only mark as true if there actually is a sentence for this language
@@ -69,10 +68,20 @@ fun extractDataFromFiles(logger: Logger, inputDirFile: File): ExtractedData {
                             RawSentence(
                                 id = sentenceId,
                                 file = file,
-                                rawConstructs = sentence,
+                                rawConstructs = sentence as String,
                             )
                         )
                 }
+            }
+
+            if (emptySentenceIds.isNotEmpty()) {
+                logger.warn(
+                    "[Warning] Skill sentences file ${lang.name}/${
+                        file.name
+                    } has no sentence definitions for these sentence ids ${
+                        emptySentenceIds
+                    }: ${file.absolutePath}"
+                )
             }
         }
 


### PR DESCRIPTION
This PR implements volume controls to the media skill. It covers both increase the volume by one (not much, not really useful, if I'm being honest) and by user specified increments.

I think this is a good approach as it allows fine control by the user. However, there is an alternative implementation where we pick some number as the increment and just have a "turn it up/down" sentence that turns audio down, say, 5 times.

Important note: The non-English sentence files are computer translated. I have no idea if they're accurate or cover reasonable user expectations. It's just a best effort to keep the compiler happy and not have language regression for the media skill.