### PR TITLE
Fix: handle unsupported locale in JokeSkill without NPE

### DIFF
--- a/app/src/main/kotlin/org/stypox/dicio/skills/joke/JokeOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/joke/JokeOutput.kt
@@ -38,4 +38,14 @@ sealed interface JokeOutput : SkillOutput {
             val ENDS_WITH_PUNCTUATION_REGEX = ".*\\p{Punct}$".toRegex()
         }
     }
+
+    class Failed : JokeOutput {
+        override fun getSpeechOutput(ctx: SkillContext): String =
+            ctx.getString(R.string.skill_joke_failed)
+
+        @Composable
+        override fun GraphicalOutput(ctx: SkillContext) {
+            Body(text = getSpeechOutput(ctx))
+        }
+    }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/skills/joke/JokeSkill.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/joke/JokeSkill.kt
@@ -13,9 +13,8 @@ import org.stypox.dicio.util.LocaleUtils
 class JokeSkill(correspondingSkillInfo: SkillInfo, data: StandardRecognizerData<Joke>)
     : StandardRecognizerSkill<Joke>(correspondingSkillInfo, data) {
     override suspend fun generateOutput(ctx: SkillContext, inputData: Joke): SkillOutput {
-        // we can use !! because the JokeInfo would have declared this skill unavailable
-        // if the current locale was not among the supported ones
-        val locale = LocaleUtils.resolveSupportedLocale(ctx.locale, JOKE_SUPPORTED_LOCALES)!!
+        val locale = LocaleUtils.resolveSupportedLocale(ctx.locale, JOKE_SUPPORTED_LOCALES)
+            ?: return JokeOutput.Failed()
 
         if (locale == "en") {
             val joke: JSONObject = ConnectionUtils.getPageJson(RANDOM_JOKE_URL_EN)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="skill_sentence_example_media">Next song</string>
     <string name="skill_name_joke">Joke</string>
     <string name="skill_sentence_example_joke">Tell me a joke</string>
+    <string name="skill_joke_failed">Sorry, jokes are not available for this language</string>
     <string name="skill_name_calculator">Calculator</string>
     <string name="skill_sentence_example_calculator">What is five times four minus a million?</string>
     <string name="skill_name_navigation">Navigation</string>

--- a/app/src/test/kotlin/org/stypox/dicio/skills/joke/JokeSkillNpeTest.kt
+++ b/app/src/test/kotlin/org/stypox/dicio/skills/joke/JokeSkillNpeTest.kt
@@ -1,0 +1,63 @@
+package org.stypox.dicio.skills.joke
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.runBlocking
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.context.SpeechOutputDevice
+import org.dicio.skill.skill.SkillOutput
+import org.dicio.numbers.ParserFormatter
+import org.dicio.skill.standard.util.MatchHelper
+import org.stypox.dicio.sentences.Sentences
+import java.util.Locale
+import android.content.Context
+
+/**
+ * Regression test for https://github.com/DicioTeam/dicio-android/pull/412
+ *
+ * When the user changes language, there is a race condition where JokeSkill.generateOutput()
+ * can be called with a locale not in JOKE_SUPPORTED_LOCALES. Previously this caused a NPE
+ * due to !! on resolveSupportedLocale(). The fix returns JokeOutput.Failed instead.
+ */
+class JokeSkillNpeTest : StringSpec({
+
+    "generateOutput returns Failed when ctx locale is not in JOKE_SUPPORTED_LOCALES" {
+        val data = Sentences.Joke["en"]!!
+        val skill = JokeSkill(JokeInfo, data)
+
+        val ctx = object : SkillContext {
+            override val locale: Locale = Locale.ITALIAN
+            override val android: Context get() = throw NotImplementedError()
+            override val sentencesLanguage: String = "it"
+            override val parserFormatter: ParserFormatter? = null
+            override val speechOutputDevice: SpeechOutputDevice get() = throw NotImplementedError()
+            override val previousOutput: SkillOutput? = null
+            override val standardMatchHelper: MatchHelper? = null
+        }
+
+        val result = runBlocking {
+            skill.generateOutput(ctx, Sentences.Joke.Command)
+        }
+        result.shouldBeInstanceOf<JokeOutput.Failed>()
+    }
+
+    "generateOutput returns Failed when locale is Turkish" {
+        val data = Sentences.Joke["en"]!!
+        val skill = JokeSkill(JokeInfo, data)
+
+        val ctx = object : SkillContext {
+            override val locale: Locale = Locale("tr")
+            override val android: Context get() = throw NotImplementedError()
+            override val sentencesLanguage: String = "tr"
+            override val parserFormatter: ParserFormatter? = null
+            override val speechOutputDevice: SpeechOutputDevice get() = throw NotImplementedError()
+            override val previousOutput: SkillOutput? = null
+            override val standardMatchHelper: MatchHelper? = null
+        }
+
+        val result = runBlocking {
+            skill.generateOutput(ctx, Sentences.Joke.Command)
+        }
+        result.shouldBeInstanceOf<JokeOutput.Failed>()
+    }
+})


### PR DESCRIPTION
When the user changes language, there is a race condition where JokeSkill.generateOutput() can be called with a locale not in JOKE_SUPPORTED_LOCALES. This happened because the SkillRanker still holds the old JokeSkill instance while ctx.locale already reflects the new locale.

The !! on resolveSupportedLocale() caused a NullPointerException. Replace with a safe return of JokeOutput.Failed.

Fixes the crash reported in DicioTeam/dicio-android#412 where changing language on first install causes an NPE in JokeSkill.

- Add JokeOutput.Failed variant with user-friendly message
- Add regression test proving the NPE scenario